### PR TITLE
[feat]: users, folders, items, schedules 엔티티 추가 및 연관관계 추가 및 화면 별 View 구조 변경

### DIFF
--- a/src/main/java/com/toit/common/enums/AuthProvider.java
+++ b/src/main/java/com/toit/common/enums/AuthProvider.java
@@ -1,4 +1,4 @@
-package com.toit.enums;
+package com.toit.common.enums;
 
 public enum AuthProvider {
     GOOGLE,

--- a/src/main/java/com/toit/common/enums/EntityStatus.java
+++ b/src/main/java/com/toit/common/enums/EntityStatus.java
@@ -1,4 +1,4 @@
-package com.toit.enums;
+package com.toit.common.enums;
 
 public enum EntityStatus {
     ACTIVE,

--- a/src/main/java/com/toit/common/enums/ItemsType.java
+++ b/src/main/java/com/toit/common/enums/ItemsType.java
@@ -1,4 +1,4 @@
-package com.toit.enums;
+package com.toit.common.enums;
 
 
 public enum ItemsType {

--- a/src/main/java/com/toit/common/enums/StorageTarget.java
+++ b/src/main/java/com/toit/common/enums/StorageTarget.java
@@ -1,4 +1,4 @@
-package com.toit.enums;
+package com.toit.common.enums;
 
 public enum StorageTarget {
     FOLDERS,

--- a/src/main/java/com/toit/folders/Folders.java
+++ b/src/main/java/com/toit/folders/Folders.java
@@ -1,6 +1,7 @@
-package com.toit.entity;
+package com.toit.folders;
 
-import com.toit.enums.EntityStatus;
+import com.toit.common.enums.EntityStatus;
+import com.toit.user.Users;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,32 +11,43 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import org.springframework.data.annotation.CreatedDate;
 
+
 @Entity
-public class Schedules {
+@Table(name = "folders")
+public class Folders {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long schedulesId;
+    private Long foldersId;
 
     /**
-     * 스케줄 제목
+     * 보관함 이름
+     * 길이 제한 50
+     */
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    /**
+     * 보관함 메모
+     * 있어도 되고, 없어도 됨
      * 길이 제한 255
      */
-    @Column(nullable = false)
-    private String title;
+    @Column(nullable = true)
+    private String memo;
 
     /**
-     * 스케줄 일정의 시작 날짜 및 시간
+     * 보관함 기본 보관함 여부
+     * 기본 보관함 이면 1, 기본 보관함이 아니면 0
      */
-    @Column(nullable = true)
-    private LocalDateTime startAt;
+    private Boolean isDefault;
 
     /**
-     * 스케줄 일정의 종료 날짜 및 시간
+     * 보관함 색깔 지정 -> #FFAAOO UI용 색상값
      */
-    @Column(nullable = true)
-    private LocalDateTime endAt;
+    @Column(length = 20)
+    private String color;
 
     /**
      * 보관함 서비스 상태
@@ -46,23 +58,29 @@ public class Schedules {
     private EntityStatus status;
 
     /**
-     * 스케줄 생성 후 시간 즉시 생성
+     * 보관함 생성 후 시간 즉시 생성
      */
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     /**
-     * 스케줄 서비스 상태가 DELETED 되면 업데이트
+     * 보관함 서비스 상태가 DELETED 되면 업데이트
      */
     @Column(nullable = true)
     private LocalDateTime deletedAt;
 
     /**
-     * Users와 N:1 관계 설정
+     * 보관함 즐겨찾기 기능
+     * 즐겨찾기 설정 -> 1, 즐겨찾기 비설정 -> 0
      */
+    private Boolean isFavorite;
+
+
     @ManyToOne
     @JoinColumn(name = "users_id", nullable = false)
     private Users users;
+
+
 
 }

--- a/src/main/java/com/toit/folders/FoldersRepository.java
+++ b/src/main/java/com/toit/folders/FoldersRepository.java
@@ -1,7 +1,5 @@
-package com.toit.repository;
+package com.toit.folders;
 
-import com.toit.entity.Folders;
-import com.toit.entity.Schedules;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/toit/items/Items.java
+++ b/src/main/java/com/toit/items/Items.java
@@ -1,8 +1,9 @@
-package com.toit.entity;
+package com.toit.items;
 
-import com.toit.enums.EntityStatus;
-import com.toit.enums.ItemsType;
-import com.toit.enums.StorageTarget;
+import com.toit.common.enums.EntityStatus;
+import com.toit.common.enums.ItemsType;
+import com.toit.common.enums.StorageTarget;
+import com.toit.user.Users;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/toit/schedules/Schedules.java
+++ b/src/main/java/com/toit/schedules/Schedules.java
@@ -1,6 +1,7 @@
-package com.toit.entity;
+package com.toit.schedules;
 
-import com.toit.enums.EntityStatus;
+import com.toit.common.enums.EntityStatus;
+import com.toit.user.Users;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,43 +11,32 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import org.springframework.data.annotation.CreatedDate;
 
-
 @Entity
-@Table(name = "folders")
-public class Folders {
+public class Schedules {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long foldersId;
+    private Long schedulesId;
 
     /**
-     * 보관함 이름
-     * 길이 제한 50
-     */
-    @Column(nullable = false, length = 50)
-    private String name;
-
-    /**
-     * 보관함 메모
-     * 있어도 되고, 없어도 됨
+     * 스케줄 제목
      * 길이 제한 255
      */
+    @Column(nullable = false)
+    private String title;
+
+    /**
+     * 스케줄 일정의 시작 날짜 및 시간
+     */
     @Column(nullable = true)
-    private String memo;
+    private LocalDateTime startAt;
 
     /**
-     * 보관함 기본 보관함 여부
-     * 기본 보관함 이면 1, 기본 보관함이 아니면 0
+     * 스케줄 일정의 종료 날짜 및 시간
      */
-    private Boolean isDefault;
-
-    /**
-     * 보관함 색깔 지정 -> #FFAAOO UI용 색상값
-     */
-    @Column(length = 20)
-    private String color;
+    @Column(nullable = true)
+    private LocalDateTime endAt;
 
     /**
      * 보관함 서비스 상태
@@ -57,29 +47,23 @@ public class Folders {
     private EntityStatus status;
 
     /**
-     * 보관함 생성 후 시간 즉시 생성
+     * 스케줄 생성 후 시간 즉시 생성
      */
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     /**
-     * 보관함 서비스 상태가 DELETED 되면 업데이트
+     * 스케줄 서비스 상태가 DELETED 되면 업데이트
      */
     @Column(nullable = true)
     private LocalDateTime deletedAt;
 
     /**
-     * 보관함 즐겨찾기 기능
-     * 즐겨찾기 설정 -> 1, 즐겨찾기 비설정 -> 0
+     * Users와 N:1 관계 설정
      */
-    private Boolean isFavorite;
-
-
     @ManyToOne
     @JoinColumn(name = "users_id", nullable = false)
     private Users users;
-
-
 
 }

--- a/src/main/java/com/toit/schedules/SchedulesRepository.java
+++ b/src/main/java/com/toit/schedules/SchedulesRepository.java
@@ -1,6 +1,6 @@
-package com.toit.repository;
+package com.toit.schedules;
 
-import com.toit.entity.Schedules;
+import com.toit.schedules.Schedules;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/toit/user/Users.java
+++ b/src/main/java/com/toit/user/Users.java
@@ -1,7 +1,9 @@
-package com.toit.entity;
+package com.toit.user;
 
-import com.toit.enums.AuthProvider;
-import com.toit.enums.EntityStatus;
+import com.toit.folders.Folders;
+import com.toit.schedules.Schedules;
+import com.toit.common.enums.AuthProvider;
+import com.toit.common.enums.EntityStatus;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/main/java/com/toit/user/UsersController.java
+++ b/src/main/java/com/toit/user/UsersController.java
@@ -1,0 +1,4 @@
+package com.toit.user;
+
+public class UsersController {
+}

--- a/src/main/java/com/toit/user/UsersRepository.java
+++ b/src/main/java/com/toit/user/UsersRepository.java
@@ -1,6 +1,5 @@
-package com.toit.repository;
+package com.toit.user;
 
-import com.toit.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/toit/user/UsersService.java
+++ b/src/main/java/com/toit/user/UsersService.java
@@ -1,0 +1,4 @@
+package com.toit.user;
+
+public class UsersService {
+}

--- a/src/main/java/com/toit/view/folders/FoldersUseCase.java
+++ b/src/main/java/com/toit/view/folders/FoldersUseCase.java
@@ -1,0 +1,4 @@
+package com.toit.view.folders;
+
+public class FoldersUseCase {
+}

--- a/src/main/java/com/toit/view/folders/FoldersUseCaseImpl.java
+++ b/src/main/java/com/toit/view/folders/FoldersUseCaseImpl.java
@@ -1,0 +1,4 @@
+package com.toit.view.folders;
+
+public class FoldersUseCaseImpl {
+}

--- a/src/main/java/com/toit/view/folders/FoldersViewController.java
+++ b/src/main/java/com/toit/view/folders/FoldersViewController.java
@@ -1,0 +1,4 @@
+package com.toit.view.folders;
+
+public class FoldersViewController {
+}

--- a/src/main/java/com/toit/view/folders/dto/FoldersViewResponse.java
+++ b/src/main/java/com/toit/view/folders/dto/FoldersViewResponse.java
@@ -1,0 +1,4 @@
+package com.toit.view.folders.dto;
+
+public class FoldersViewResponse {
+}

--- a/src/main/java/com/toit/view/home/HomeUseCase.java
+++ b/src/main/java/com/toit/view/home/HomeUseCase.java
@@ -1,0 +1,4 @@
+package com.toit.view.home;
+
+public class HomeUseCase {
+}

--- a/src/main/java/com/toit/view/home/HomeUseCaseImpl.java
+++ b/src/main/java/com/toit/view/home/HomeUseCaseImpl.java
@@ -1,0 +1,4 @@
+package com.toit.view.home;
+
+public class HomeUseCaseImpl {
+}

--- a/src/main/java/com/toit/view/home/HomeViewController.java
+++ b/src/main/java/com/toit/view/home/HomeViewController.java
@@ -1,0 +1,4 @@
+package com.toit.view.home;
+
+public class HomeViewController {
+}

--- a/src/main/java/com/toit/view/home/dto/HomeViewResponse.java
+++ b/src/main/java/com/toit/view/home/dto/HomeViewResponse.java
@@ -1,0 +1,4 @@
+package com.toit.view.home.dto;
+
+public class HomeViewResponse {
+}


### PR DESCRIPTION
변경 사항
- users 엔티티 추가 및 folders, items 연관관계 추가(folders, items 연관관계의 주인 N:1 관계)
- 패키지 중 users, folders, items, schedules 패키지는 각 서비스 로직, view 패키지는 화면 별 API 구성

