### PR TITLE
feat(users): users 하나 생성 API 추가

### DIFF
--- a/src/main/java/com/toit/user/Users.java
+++ b/src/main/java/com/toit/user/Users.java
@@ -85,4 +85,14 @@ public class Users {
     @OneToMany(mappedBy = "users")
     private List<Folders> items = new ArrayList<>();
 
+    public Users(String email, String name, String bio, AuthProvider authProvider, Long providerUsersId, LocalDateTime createdAt
+    ) {
+        this.email = email;
+        this.name = name;
+        this.bio = bio;
+        this.authProvider = authProvider;
+        this.providerUsersId = providerUsersId;
+        this.status = EntityStatus.ACTIVE;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/toit/user/UsersController.java
+++ b/src/main/java/com/toit/user/UsersController.java
@@ -1,4 +1,27 @@
 package com.toit.user;
 
+import com.toit.user.dto.request.UsersCreateRequest;
+import com.toit.user.dto.response.UsersCreateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
 public class UsersController {
+
+    private final UsersService usersService;
+
+    /** 사용자 생성 - 카카오 로그인 전 임시 */
+    @PostMapping
+    public ResponseEntity<UsersCreateResponse> createUser(
+            @RequestBody UsersCreateRequest request
+    ) {
+        return ResponseEntity.ok(usersService.createUser(request));
+    }
+
 }

--- a/src/main/java/com/toit/user/UsersService.java
+++ b/src/main/java/com/toit/user/UsersService.java
@@ -1,5 +1,9 @@
 package com.toit.user;
 
+import com.toit.common.enums.AuthProvider;
+import com.toit.user.dto.request.UsersCreateRequest;
+import com.toit.user.dto.response.UsersCreateResponse;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -8,6 +12,21 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UsersService {
     private final UsersRepository usersRepository;
+
+
+    public UsersCreateResponse createUser(UsersCreateRequest request) {
+        Users users = new Users(
+                request.getEmail(),
+                request.getName(),
+                request.getBio(),
+                AuthProvider.valueOf(request.getAuthProvider()),
+                request.getProviderUsersId(),
+                LocalDateTime.now()
+        );
+
+        return new UsersCreateResponse(usersRepository.save(users));
+    }
+
 
     public Users findById(Long usersId){
         Optional<Users> users = usersRepository.findById(usersId);

--- a/src/main/java/com/toit/user/dto/request/UsersCreateRequest.java
+++ b/src/main/java/com/toit/user/dto/request/UsersCreateRequest.java
@@ -1,0 +1,25 @@
+package com.toit.user.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UsersCreateRequest {
+
+    /** 사용자 이메일 */
+    private String email;
+
+    /** 사용자 이름 */
+    private String name;
+
+    /** 사용자 자기소개 */
+    private String bio;
+
+    /**  "KAKAO", "GOOGLE" */
+    private String authProvider;
+
+    /** 사용자 OAuth 식별자 - OAuth 2.0으로 가져온 값 -> 랜던값으로 진행 */
+    private Long providerUsersId;
+}

--- a/src/main/java/com/toit/user/dto/response/UsersCreateResponse.java
+++ b/src/main/java/com/toit/user/dto/response/UsersCreateResponse.java
@@ -1,0 +1,29 @@
+package com.toit.user.dto.response;
+
+import com.toit.common.enums.AuthProvider;
+import com.toit.user.Users;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UsersCreateResponse {
+
+    private Long usersId;
+    private String email;
+    private String name;
+    private AuthProvider authProvider;
+    private Long providerUsersId;
+    private LocalDateTime createdAt;
+
+    public UsersCreateResponse(Users users) {
+        this.usersId = users.getUsersId();
+        this.email = users.getEmail();
+        this.name = users.getName();
+        this.authProvider = users.getAuthProvider();
+        this.providerUsersId = users.getProviderUsersId();
+        this.createdAt = users.getCreatedAt();
+    }
+}


### PR DESCRIPTION
## 변경 내용
- OAuth을 통해 로그인을 구현하기 전 임시로 더미데이터를 위해 Users를 하나 생성하는 API 추가 하였습니다.
- UsersCreateRequest 생성
- UsersCreateResponse 생성
- Users 생성자 생성

Closes: #26 