### PR TITLE
feat(folders): 보관함 전체 조회 API 추가

### DIFF
--- a/src/main/java/com/toit/folders/Folders.java
+++ b/src/main/java/com/toit/folders/Folders.java
@@ -15,13 +15,16 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 
 
 @Entity
 @Table(name = "folders")
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Folders {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long foldersId;

--- a/src/main/java/com/toit/folders/FoldersController.java
+++ b/src/main/java/com/toit/folders/FoldersController.java
@@ -1,9 +1,12 @@
 package com.toit.folders;
 
+import com.toit.folders.dto.request.FoldersAllRequest;
 import com.toit.folders.dto.request.FoldersCreateRequest;
+import com.toit.folders.dto.response.FoldersAllResponse;
 import com.toit.folders.dto.response.FoldersCreateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,4 +31,15 @@ public class FoldersController {
         return ResponseEntity.ok(foldersService.createFolders(request));
     }
 
+    /**
+     * <h2>Folders 보관함 전체 조회 API</h2>
+     *
+     * <p>한 명의 사용자가 접근 가능한 모든 보관함을 조회합니다.</p>
+     */
+    @GetMapping("/all")
+    public ResponseEntity<FoldersAllResponse> getAllFoldersByUser(
+            @RequestBody FoldersAllRequest request
+    ){
+        return ResponseEntity.ok(foldersService.getAllFoldersByUser(request));
+    }
 }

--- a/src/main/java/com/toit/folders/FoldersRepository.java
+++ b/src/main/java/com/toit/folders/FoldersRepository.java
@@ -1,10 +1,11 @@
 package com.toit.folders;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 
 @Repository
 public interface FoldersRepository extends  JpaRepository<Folders, Long>{
-
+    List<Folders> findByUsers_UsersId(Long usersId);
 }

--- a/src/main/java/com/toit/folders/FoldersService.java
+++ b/src/main/java/com/toit/folders/FoldersService.java
@@ -1,10 +1,14 @@
 package com.toit.folders;
 
+import com.toit.folders.dto.request.FoldersAllRequest;
 import com.toit.folders.dto.request.FoldersCreateRequest;
+import com.toit.folders.dto.response.FoldersAllResponse;
 import com.toit.folders.dto.response.FoldersCreateResponse;
+import com.toit.folders.dto.response.FoldersItemResponse;
 import com.toit.user.Users;
 import com.toit.user.UsersService;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +19,11 @@ public class FoldersService {
 
     private final UsersService usersService;
 
+    /**
+     * <h2>Folders 보관함 하나 생성 비즈니스 로직</h2>
+     * @param request
+     * @return
+     */
     public FoldersCreateResponse createFolders(FoldersCreateRequest request) {
         /** Users 조회 -> Users 예외 처리 */
         Users users = usersService.findById(request.getUsersId());
@@ -29,5 +38,15 @@ public class FoldersService {
                 users
         );
         return new FoldersCreateResponse(foldersRepository.save(folders));
+    }
+
+    public FoldersAllResponse getAllFoldersByUser(FoldersAllRequest request) {
+        Long userId = request.getUsersId();
+        usersService.findById(userId);
+        List<FoldersItemResponse> folders = foldersRepository.findByUsers_UsersId(userId)
+                .stream()
+                .map(FoldersItemResponse::new)
+                .toList();
+        return new FoldersAllResponse(userId, folders);
     }
 }

--- a/src/main/java/com/toit/folders/dto/request/FoldersAllRequest.java
+++ b/src/main/java/com/toit/folders/dto/request/FoldersAllRequest.java
@@ -1,0 +1,18 @@
+package com.toit.folders.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FoldersAllRequest {
+    /**
+     * 사용자 ID
+     * */
+    private Long usersId;
+
+    public FoldersAllRequest(Long usersId){
+        this.usersId = usersId;
+    }
+}

--- a/src/main/java/com/toit/folders/dto/response/FoldersAllResponse.java
+++ b/src/main/java/com/toit/folders/dto/response/FoldersAllResponse.java
@@ -1,0 +1,18 @@
+package com.toit.folders.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FoldersAllResponse {
+    private Long userId;
+    private List<FoldersItemResponse> folders;
+
+    public FoldersAllResponse(Long userId, List<FoldersItemResponse> folders) {
+        this.userId = userId;
+        this.folders = folders;
+    }
+}

--- a/src/main/java/com/toit/folders/dto/response/FoldersItemResponse.java
+++ b/src/main/java/com/toit/folders/dto/response/FoldersItemResponse.java
@@ -1,0 +1,31 @@
+package com.toit.folders.dto.response;
+
+import com.toit.folders.Folders;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FoldersItemResponse {
+    private Long foldersId;
+    private Long usersId;
+    private String name;
+    private String memo;
+    private Boolean isDefault;
+    private String color;
+    private LocalDateTime createdAt;
+    private Boolean isFavorite;
+
+    public FoldersItemResponse(Folders folders) {
+        this.foldersId = folders.getFoldersId();
+        this.usersId = folders.getUsers().getUsersId();
+        this.name = folders.getName();
+        this.memo = folders.getMemo();
+        this.isDefault = folders.getIsDefault();
+        this.color = folders.getColor();
+        this.isFavorite = folders.getIsFavorite();
+        this.createdAt = folders.getCreatedAt();
+    }
+}

--- a/src/main/java/com/toit/user/Users.java
+++ b/src/main/java/com/toit/user/Users.java
@@ -80,13 +80,6 @@ public class Users {
     @OneToMany(mappedBy = "users")
     private List<Schedules> schedules = new ArrayList<>();
 
-    /**
-     * 보관함(folders)와 1:N 관계
-     * 외래 키의 주인은 Folders
-     */
-    @OneToMany(mappedBy = "users")
-    private List<Folders> items = new ArrayList<>();
-
     public Users(String email, String name, String bio, AuthProvider authProvider, Long providerUsersId, LocalDateTime createdAt
     ) {
         this.email = email;


### PR DESCRIPTION
## 변경 내용
- Request 경우 DTO를 FoldersAllRequest로 구성
- Response 경우 DTO를 하나의 폴더를 FoldersItemResponse를 List로 구성 후 FoldersALLResponse에 userId랑 추가 
- Users와 Folders의 양방향 관계를 단방향 관계로 변경

Closes: #36 