### PR TITLE
feat(foldersviews): 최근 본 보관함 조회

### DIFF
--- a/src/main/java/com/toit/foldersview/FoldersViews.java
+++ b/src/main/java/com/toit/foldersview/FoldersViews.java
@@ -1,0 +1,51 @@
+package com.toit.foldersview;
+
+import com.toit.folders.Folders;
+import com.toit.user.Users;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@Table(name = "folders_views")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FoldersViews {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long foldersViewsId;
+
+
+    /**
+     * 최근 본 폴더 시간
+     */
+    @Column(nullable = false)
+    private LocalDateTime lastViewedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "users_id", nullable = false)
+    private Users users;
+
+    @ManyToOne
+    @JoinColumn(name = "folders_id", nullable = false)
+    private Folders folder;
+
+    public FoldersViews(Folders folder, Users users) {
+        this.folder = folder;
+        this.users = users;
+        this.lastViewedAt = LocalDateTime.now();
+    }
+
+    public void updateLastViewed() {
+        this.lastViewedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/toit/foldersview/FoldersViewsController.java
+++ b/src/main/java/com/toit/foldersview/FoldersViewsController.java
@@ -1,0 +1,45 @@
+package com.toit.foldersview;
+
+import com.toit.foldersview.dto.request.FoldersViewsRequest;
+import com.toit.foldersview.dto.request.RecentFoldersRequest;
+import com.toit.foldersview.dto.response.FoldersViewsResponse;
+import com.toit.foldersview.dto.response.RecentFoldersResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/foldersviews")
+@RequiredArgsConstructor
+public class FoldersViewsController {
+
+    private final FoldersViewsService foldersViewsService;
+
+    /**
+     * 최근 본 보관함 이력 업데이트 없으면 리소스 생성
+     */
+    @PostMapping
+    public ResponseEntity<FoldersViewsResponse> recordFoldersViews(
+            @RequestBody FoldersViewsRequest request
+    ){
+        return ResponseEntity.ok(foldersViewsService.recordFoldersViews(request));
+    }
+
+    /**
+     * 최근 본 폴더 최대 4개 까지 보내줌
+     */
+    @GetMapping
+    public ResponseEntity<List<RecentFoldersResponse>> getRecentFolders(
+            @RequestBody FoldersViewsRequest request
+    ) {
+        return ResponseEntity.ok(foldersViewsService.getRecentFolders(request));
+    }
+
+
+
+}

--- a/src/main/java/com/toit/foldersview/FoldersViewsRepository.java
+++ b/src/main/java/com/toit/foldersview/FoldersViewsRepository.java
@@ -1,0 +1,33 @@
+package com.toit.foldersview;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface FoldersViewsRepository extends JpaRepository<FoldersViews, Long> {
+    /**
+     * FoldersViews 엔티티에서 users.usersId 가 주어진 usersId 이고
+     * folder.foldersId 가 주어진 folderId 인 것 하나를 찾는다
+     * @param usersId
+     * @param foldersId
+     * @return
+     */
+    Optional<FoldersViews> findByUsers_UsersIdAndFolder_FoldersId(Long usersId, Long foldersId);
+
+    @Query("""
+        select fv
+        from FoldersViews fv
+        where fv.users.usersId = :usersId
+        order by fv.lastViewedAt desc
+    """)
+    List<FoldersViews> findRecentFoldersByUser(
+            @Param("usersId") Long usersId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/toit/foldersview/FoldersViewsService.java
+++ b/src/main/java/com/toit/foldersview/FoldersViewsService.java
@@ -1,0 +1,66 @@
+package com.toit.foldersview;
+
+import com.toit.folders.Folders;
+import com.toit.folders.FoldersRepository;
+import com.toit.foldersview.dto.request.FoldersViewsRequest;
+import com.toit.foldersview.dto.response.FoldersViewsResponse;
+import com.toit.foldersview.dto.response.RecentFoldersResponse;
+import com.toit.user.Users;
+import com.toit.user.UsersService;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FoldersViewsService {
+
+    private final FoldersViewsRepository foldersViewsRepository;
+    private final UsersService usersService;
+    private final FoldersRepository foldersRepository;
+
+    /**
+     * 사용자가 본 폴더가 이미 리소스가 있으면 본 시간 업데이트
+     * 사용자가 처음 본 폴더이면 리소스 생성
+     * @param request
+     */
+    public FoldersViewsResponse recordFoldersViews(FoldersViewsRequest request) {
+        Long usersId = request.getUsersId();
+        Long foldersId = request.getFoldersId();
+        Users user = usersService.findById(usersId);
+        Folders folder = foldersRepository.findById(foldersId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 폴더입니다. folderId=" + foldersId));
+
+        Optional<FoldersViews> optionalViews =
+                foldersViewsRepository.findByUsers_UsersIdAndFolder_FoldersId(usersId, foldersId);
+
+        FoldersViews result;
+
+        if (optionalViews.isPresent()) {
+            result = optionalViews.get();
+            result.updateLastViewed(); // 더티체킹이 일어남
+        } else {
+            result = foldersViewsRepository.save(new FoldersViews(folder, user));
+        }
+        return new FoldersViewsResponse(result);
+    }
+
+    /**
+     *  Pageable을 사용해서 최대 4개까지 뽑아서 보내줌
+     *  4개는 내림차순으로 정렬해서 보내주게 됨
+     */
+    public List<RecentFoldersResponse> getRecentFolders(FoldersViewsRequest request) {
+        Long usersId = request.getUsersId();
+
+        // 사용자 존재 검증
+        usersService.findById(usersId);
+
+        return foldersViewsRepository
+                .findRecentFoldersByUser(usersId, PageRequest.of(0, 4))
+                .stream()
+                .map(RecentFoldersResponse::new)
+                .toList();
+    }
+}

--- a/src/main/java/com/toit/foldersview/dto/request/FoldersViewsRequest.java
+++ b/src/main/java/com/toit/foldersview/dto/request/FoldersViewsRequest.java
@@ -1,0 +1,25 @@
+package com.toit.foldersview.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FoldersViewsRequest {
+
+    /**
+     * 사용자 ID
+     * */
+    private Long usersId;
+
+    /**
+     * 보관함 ID
+     */
+    private Long foldersId;
+
+    public FoldersViewsRequest(Long usersId, Long foldersId){
+        this.usersId = usersId;
+        this.foldersId = foldersId;
+    }
+}

--- a/src/main/java/com/toit/foldersview/dto/request/RecentFoldersRequest.java
+++ b/src/main/java/com/toit/foldersview/dto/request/RecentFoldersRequest.java
@@ -1,0 +1,14 @@
+package com.toit.foldersview.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecentFoldersRequest {
+    /**
+     * 사용자 ID
+     */
+    private Long usersId;
+}

--- a/src/main/java/com/toit/foldersview/dto/response/FoldersViewsResponse.java
+++ b/src/main/java/com/toit/foldersview/dto/response/FoldersViewsResponse.java
@@ -1,0 +1,23 @@
+package com.toit.foldersview.dto.response;
+
+import com.toit.foldersview.FoldersViews;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FoldersViewsResponse {
+    private Long foldersViewsId;
+    private Long usersId;
+    private Long foldersId;
+    private LocalDateTime lastViewedAt;
+
+    public FoldersViewsResponse(FoldersViews views) {
+        this.foldersViewsId = views.getFoldersViewsId();
+        this.usersId = views.getUsers().getUsersId();
+        this.foldersId = views.getFolder().getFoldersId();
+        this.lastViewedAt = views.getLastViewedAt();
+    }
+}

--- a/src/main/java/com/toit/foldersview/dto/response/RecentFoldersResponse.java
+++ b/src/main/java/com/toit/foldersview/dto/response/RecentFoldersResponse.java
@@ -1,0 +1,22 @@
+package com.toit.foldersview.dto.response;
+
+import com.toit.foldersview.FoldersViews;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecentFoldersResponse {
+
+    private Long folderId;
+    private String name;
+    private LocalDateTime lastViewedAt;
+
+    public RecentFoldersResponse(FoldersViews views) {
+        this.folderId = views.getFolder().getFoldersId();
+        this.name = views.getFolder().getName();
+        this.lastViewedAt = views.getLastViewedAt();
+    }
+}


### PR DESCRIPTION
## 변경 내용
- 최근 본 보관함 이력 저장 API(POST) 추가 저장시 리소스 서버에 이미 해당 데이터가 존재하면 컬럼만 업데이트 없으면 리소스 새로 생성
- 최근 본 보관함 이력 4개 조회 API(GET) 추가 JPQL로 개발 진행하였으며 Pageable을 통해 구현 이력은 조회한 날짜 및 시간을 내림차순하여 보내줌

Closes: #39 