### PR TITLE
feature/하나의 일정 생성 && 하루 일정 조회 && 일정 조회

### DIFF
--- a/src/main/java/com/toit/schedules/Schedules.java
+++ b/src/main/java/com/toit/schedules/Schedules.java
@@ -42,18 +42,19 @@ public class Schedules {
     /***
      * 스케줄의 시간 설정 여부 (False = 시간 설정 안함 , True = 시간 설정했을 때)
      */
+    @Column(nullable = false)
     private Boolean timeSetting;
 
     /**
      * 스케줄 일정의 시작 날짜
      */
-    @Column(nullable = true)
+    @Column(nullable = false)
     private LocalDate startDate;
 
     /**
      * 스케줄 일정의 종료 날짜
      */
-    @Column(nullable = true)
+    @Column(nullable = false)
     private LocalDate endDate;
 
     /**

--- a/src/main/java/com/toit/schedules/SchedulesController.java
+++ b/src/main/java/com/toit/schedules/SchedulesController.java
@@ -3,8 +3,10 @@ package com.toit.schedules;
 
 
 import com.toit.schedules.dto.request.SchedulesCreateRequest;
+import com.toit.schedules.dto.request.SchedulesMonthRequest;
 import com.toit.schedules.dto.request.SchedulesTodayRequest;
 import com.toit.schedules.dto.response.SchedulesCreateResponse;
+import com.toit.schedules.dto.response.SchedulesMonthResponse;
 import com.toit.schedules.dto.response.SchedulesTodayResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -18,22 +20,8 @@ import org.springframework.web.bind.annotation.*;
 public class SchedulesController {
     private final SchedulesService schedulesService;
 
-    /*
-     *  조회 (GET)
-     */
-
     /***
-     * 오늘 일정 조회
-     */
-    @GetMapping("/today")
-    public ResponseEntity<SchedulesTodayResponse> getTodaySchedules(
-            @RequestBody SchedulesTodayRequest request
-            ) {
-        return ResponseEntity.ok(schedulesService.getTodaySchedules(request));
-    }
-
-    /*
-     * 생성 (POST)
+     * 생성 영역
      */
 
     /***

--- a/src/main/java/com/toit/schedules/SchedulesRepository.java
+++ b/src/main/java/com/toit/schedules/SchedulesRepository.java
@@ -2,6 +2,8 @@ package com.toit.schedules;
 
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -11,13 +13,20 @@ import java.util.List;
 public interface SchedulesRepository extends JpaRepository<Schedules, Long> {
 
 
-    /**
-     * 특정 유저의 일정 중 오늘 날짜가 포함된(startDate <= today <= endDate) 일정 조회
-     */
-    List<Schedules> findByUsersUsersIdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
-            Long usersId,
-            LocalDate todayForStart,
-            LocalDate todayForEnd
-    );
+    /** 오늘 일정 조회 */
+    @Query("SELECT s FROM Schedules s " +
+            "WHERE s.users.usersId = :userId " +
+            "AND :targetDate BETWEEN s.startDate AND s.endDate " +
+            "ORDER BY s.startTime ASC")
+    List<Schedules> findTodaySchedules(@Param("userId") Long userId,
+                                       @Param("targetDate") LocalDate targetDate);
 
+    /** 시작날짜 종료날짜 사이 일정 조회 */
+    @Query("SELECT s FROM Schedules s " +
+            "WHERE s.users.usersId = :userId " +
+            "AND s.startDate BETWEEN :startDate AND :endDate " +
+            "ORDER BY s.startDate ASC, s.startTime ASC")
+    List<Schedules> findSchedulesBetween(@Param("userId") Long userId,
+                                         @Param("startDate") LocalDate startDate,
+                                         @Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/com/toit/schedules/dto/SchedulesMonthDto.java
+++ b/src/main/java/com/toit/schedules/dto/SchedulesMonthDto.java
@@ -1,0 +1,37 @@
+package com.toit.schedules.dto;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SchedulesMonthDto {
+
+    /** 스케줄 ID */
+    private Long schedulesId;
+
+    /** 스케줄 제목 */
+    private String title;
+
+    /** 시작 날짜  */
+    private LocalDate startDate;
+
+    /** 종료 날짜 */
+    private LocalDate endDate;
+
+    /** 위젯 색상 */
+    private String appColor;
+
+    public SchedulesMonthDto(Long schedulesId, String title, LocalDate startDate, LocalDate endDate, String appColor) {
+        this.schedulesId = schedulesId;
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.appColor = appColor;
+    }
+}

--- a/src/main/java/com/toit/schedules/dto/SchedulesTodayDto.java
+++ b/src/main/java/com/toit/schedules/dto/SchedulesTodayDto.java
@@ -1,6 +1,5 @@
 package com.toit.schedules.dto;
 
-import com.toit.schedules.Schedules;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/toit/schedules/dto/request/SchedulesMonthRequest.java
+++ b/src/main/java/com/toit/schedules/dto/request/SchedulesMonthRequest.java
@@ -1,0 +1,19 @@
+package com.toit.schedules.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SchedulesMonthRequest {
+    /** 사용자 ID */
+    private Long usersId;
+    /** 오늘 날짜  */
+    private LocalDate startDate;
+    /** 종료 날짜  */
+    private LocalDate endDate;
+}

--- a/src/main/java/com/toit/schedules/dto/response/SchedulesMonthResponse.java
+++ b/src/main/java/com/toit/schedules/dto/response/SchedulesMonthResponse.java
@@ -1,0 +1,24 @@
+package com.toit.schedules.dto.response;
+
+import com.toit.schedules.dto.SchedulesMonthDto;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SchedulesMonthResponse {
+
+    /** 사용자 ID */
+    private  Long userId;
+
+    /** 필요한 스케줄의 값들을 리스트로 반환  */
+    private List<SchedulesMonthDto> schedules;
+
+    public SchedulesMonthResponse(Long userId, List<SchedulesMonthDto> schedules) {
+        this.userId = userId;
+        this.schedules = schedules;
+    }
+}

--- a/src/main/java/com/toit/user/Users.java
+++ b/src/main/java/com/toit/user/Users.java
@@ -1,13 +1,11 @@
 package com.toit.user;
 
-import com.toit.folders.Folders;
-import com.toit.schedules.Schedules;
+
 import com.toit.common.enums.AuthProvider;
 import com.toit.common.enums.EntityStatus;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -72,13 +70,6 @@ public class Users {
     @Column(nullable = true)
     private LocalDateTime deletedAt;
 
-    /**
-     * 스케줄(schedules)과 1:N 관계
-     * 외래 키의 주인은 Schedules
-     */
-    //1:N 관계
-    @OneToMany(mappedBy = "users")
-    private List<Schedules> schedules = new ArrayList<>();
 
     public Users(String email, String name, String bio, AuthProvider authProvider, Long providerUsersId, LocalDateTime createdAt
     ) {


### PR DESCRIPTION
## 변경 내용
- 일정 생성 API 추가
- SchedulesCreateRequest 추가
- SchedulesCreateResponse 추가
- 오늘 일정 조회 API 추가
- SchedulesTodayRequest 추가
- SchedulesTodayResponse 추가
- 범위 일정 조회 API 추가
- SchedulesMonthRequest 추가
- SchedulesMonthResponse 추가
- 연관관계 수정
- Users 양방향 관계에서 단방향 관계로 수정

Closes: #30 
Closes: #35