### PR TITLE
feature/일정 첨부자료 목록/상세 조회

### DIFF
--- a/src/main/java/com/toit/schedules/SchedulesRepository.java
+++ b/src/main/java/com/toit/schedules/SchedulesRepository.java
@@ -18,7 +18,7 @@ public interface SchedulesRepository extends JpaRepository<Schedules, Long> {
             "WHERE s.users.usersId = :userId " +
             "AND :targetDate BETWEEN s.startDate AND s.endDate " +
             "ORDER BY s.startTime ASC")
-    List<Schedules> findTodaySchedules(@Param("userId") Long userId,
+    List<Schedules> findSelectedDaySchedules(@Param("userId") Long userId,
                                        @Param("targetDate") LocalDate targetDate);
 
     /** 시작날짜 종료날짜 사이 일정 조회 */

--- a/src/main/java/com/toit/schedules/dto/response/SchedulesSelectedDayResponse.java
+++ b/src/main/java/com/toit/schedules/dto/response/SchedulesSelectedDayResponse.java
@@ -8,14 +8,14 @@ import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SchedulesTodayResponse {
+public class SchedulesSelectedDayResponse {
     private Long schedulesId;
     private String title;
     private LocalTime startTime;
     private LocalTime endTime;
     private String appColor;
 
-    public SchedulesTodayResponse(Long schedulesId, String title, LocalTime startTime, LocalTime endTime, String appColor) {
+    public SchedulesSelectedDayResponse(Long schedulesId, String title, LocalTime startTime, LocalTime endTime, String appColor) {
         this.schedulesId = schedulesId;
         this.title = title;
         this.startTime = startTime;

--- a/src/main/java/com/toit/view/home/HomeUseCaseImpl.java
+++ b/src/main/java/com/toit/view/home/HomeUseCaseImpl.java
@@ -5,14 +5,12 @@ import com.toit.folders.dto.response.FoldersItemResponse;
 import com.toit.foldersview.FoldersViewsService;
 import com.toit.foldersview.dto.response.RecentFoldersResponse;
 import com.toit.schedules.SchedulesService;
-import com.toit.schedules.dto.response.SchedulesTodayResponse;
-import com.toit.view.home.dto.request.HomeViewRequest;
+import com.toit.schedules.dto.response.SchedulesSelectedDayResponse;
 import com.toit.view.home.dto.response.HomeViewResponse;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +29,7 @@ public class HomeUseCaseImpl implements HomeUseCase {
         List<FoldersItemResponse> folders = foldersService.getAllFoldersByUser(usersId);
 
         // 오늘 일정 조회
-        List<SchedulesTodayResponse> schedules = schedulesService.getTodaySchedules(usersId, todayDate);
+        List<SchedulesSelectedDayResponse> schedules = schedulesService.getSelectedDaySchedules(usersId, todayDate);
 
         return new HomeViewResponse(usersId, folders, foldersViews, schedules);
     }

--- a/src/main/java/com/toit/view/home/dto/response/HomeViewResponse.java
+++ b/src/main/java/com/toit/view/home/dto/response/HomeViewResponse.java
@@ -2,7 +2,7 @@ package com.toit.view.home.dto.response;
 
 import com.toit.folders.dto.response.FoldersItemResponse;
 import com.toit.foldersview.dto.response.RecentFoldersResponse;
-import com.toit.schedules.dto.response.SchedulesTodayResponse;
+import com.toit.schedules.dto.response.SchedulesSelectedDayResponse;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -29,10 +29,10 @@ public class HomeViewResponse {
     /**
      * 오늘 일정 조회
      */
-    private List<SchedulesTodayResponse> schedules;
+    private List<SchedulesSelectedDayResponse> schedules;
 
     public HomeViewResponse(Long userId, List<FoldersItemResponse> folders, List<RecentFoldersResponse> foldersViews
-            , List<SchedulesTodayResponse> schedules) {
+            , List<SchedulesSelectedDayResponse> schedules) {
         this.userId = userId;
         this.folders = folders;
         this.foldersViews = foldersViews;

--- a/src/main/java/com/toit/view/schedules/SchedulesUseCase.java
+++ b/src/main/java/com/toit/view/schedules/SchedulesUseCase.java
@@ -1,6 +1,10 @@
 package com.toit.view.schedules;
 
+
+import com.toit.schedules.dto.response.ScheduleViewResponse;
 import com.toit.view.schedules.dto.response.SchedulesSearchResponse;
+import com.toit.view.schedules.dto.response.SchedulesSelectDayViewResponse;
+
 
 import java.time.LocalDate;
 
@@ -8,4 +12,7 @@ public interface SchedulesUseCase {
 
     SchedulesSearchResponse getSearchSchedulesView(Long usersId, LocalDate startDate, LocalDate endDate);
 
+    SchedulesSelectDayViewResponse getSelectedDayScheduleView(Long usersId, LocalDate selectedDay);
+
+    ScheduleViewResponse getScheduleView(Long usersId, Long schedulesId);
 }

--- a/src/main/java/com/toit/view/schedules/SchedulesUseCaseImpl.java
+++ b/src/main/java/com/toit/view/schedules/SchedulesUseCaseImpl.java
@@ -2,9 +2,11 @@ package com.toit.view.schedules;
 
 
 import com.toit.schedules.SchedulesService;
+import com.toit.schedules.dto.response.ScheduleViewResponse;
 import com.toit.schedules.dto.response.SchedulesMonthResponse;
+import com.toit.schedules.dto.response.SchedulesSelectedDayResponse;
 import com.toit.view.schedules.dto.response.SchedulesSearchResponse;
-
+import com.toit.view.schedules.dto.response.SchedulesSelectDayViewResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,12 +19,47 @@ public class SchedulesUseCaseImpl implements SchedulesUseCase{
 
     private final SchedulesService schedulesService;
 
+    /***
+     * startDate ~ endDate 범위 내의 일정들을 반환
+     */
     @Override
-    public SchedulesSearchResponse getSearchSchedulesView(Long usersId, LocalDate startDate,LocalDate endDate) {
+    public SchedulesSearchResponse getSearchSchedulesView(Long usersId, LocalDate startDate, LocalDate endDate) {
 
         List<SchedulesMonthResponse> schedules = schedulesService.getSearchSchedules(usersId, startDate, endDate);
 
         return new SchedulesSearchResponse(usersId, schedules);
+    }
+
+    /***
+     * 선택된 날짜의 스케줄들을 반환
+     */
+    @Override
+    public SchedulesSelectDayViewResponse getSelectedDayScheduleView(Long userId, LocalDate selectedDay){
+        List<SchedulesSelectedDayResponse> schedules = schedulesService.getSelectedDaySchedules(userId, selectedDay);
+
+        return  new SchedulesSelectDayViewResponse(userId, schedules) ;
+
+    }
+
+    @Override
+    public ScheduleViewResponse getScheduleView(Long usersId, Long schedulesId){
+        ScheduleViewResponse schedule = schedulesService.getSchedule(usersId, schedulesId);
+
+        return new ScheduleViewResponse(
+                schedule.getUserId(),
+                schedule.getSchedulesId(),
+                schedule.getTitle(),
+                schedule.getFoldersId(),
+                schedule.getFoldersTitle(),
+                schedule.getTimeSetting(),
+                schedule.getStartDate(),
+                schedule.getEndDate(),
+                schedule.getStartTime(),
+                schedule.getEndTime(),
+                schedule.getLocation(),
+                schedule.getNotification(),
+                schedule.getMemo()
+        );
     }
 
 

--- a/src/main/java/com/toit/view/schedules/SchedulesViewController.java
+++ b/src/main/java/com/toit/view/schedules/SchedulesViewController.java
@@ -1,8 +1,13 @@
 package com.toit.view.schedules;
 
 
+import com.toit.schedules.dto.request.ScheduleViewRequest;
+import com.toit.schedules.dto.response.ScheduleViewResponse;
 import com.toit.view.schedules.dto.request.ScheduleSearchRequest;
+import com.toit.view.schedules.dto.request.SchedulesSelectDayRequest;
 import com.toit.view.schedules.dto.response.SchedulesSearchResponse;
+import com.toit.view.schedules.dto.response.SchedulesSelectDayViewResponse;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +22,9 @@ public class SchedulesViewController {
 
     private final SchedulesUseCase schedulesUseCase;
 
+    /**
+     * startDate ~ endDate 내의 일정 조회
+     */
     @GetMapping("/search")
     public ResponseEntity<SchedulesSearchResponse> getSearchSchedules(
             @RequestBody ScheduleSearchRequest request
@@ -26,5 +34,32 @@ public class SchedulesViewController {
                         request.getUserId(),
                         request.getStartDate(),
                         request.getEndDate()));
+    }
+
+    /**
+     * 선택한 날짜에 해당하는 일정 조회
+     */
+    @GetMapping("/selected")
+    public ResponseEntity<SchedulesSelectDayViewResponse> getSelectedDaySchedules(
+            @RequestBody SchedulesSelectDayRequest request
+            ){
+
+        return ResponseEntity.ok(schedulesUseCase.
+                getSelectedDayScheduleView(
+                        request.getUsersId(),
+                        request.getSelectedDay()));
+
+    }
+
+    @GetMapping("/detail")
+    public ResponseEntity<ScheduleViewResponse> getSchedule(
+            @RequestBody ScheduleViewRequest request
+            ){
+
+        return ResponseEntity.ok(schedulesUseCase.
+                getScheduleView(
+                        request.getUsersId(),
+                        request.getSchedulesId()));
+
     }
 }

--- a/src/main/java/com/toit/view/schedules/dto/request/SchedulesSelectDayRequest.java
+++ b/src/main/java/com/toit/view/schedules/dto/request/SchedulesSelectDayRequest.java
@@ -1,0 +1,20 @@
+package com.toit.view.schedules.dto.request;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/***
+ * 선택한 날짜의 일정을 조회하는 request
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SchedulesSelectDayRequest {
+    /** 사용자 ID* */
+    private Long usersId ;
+    /** 조회할 시작 날짜 ID* */
+    private LocalDate selectedDay;
+}


### PR DESCRIPTION
## 변경 내용
- SchedulesSelectDayRequest오늘 날짜 반환 -> 선택한 날짜의 일정을 반환하는 Response 를 공용으로 사용하기 위해 클래스명 변경 
- SchedulesSelectedDayResponse 위와 똑같이 클래스명 변경
- SchedulesService 일정의 상세보기 로직 추가 
- 화면별 API 선택한 날짜 일정 리스트 조회 기능 추가 
- 화면별 API 선택한 일정 상세보기 기능 추가

Closes: #59