### PR TITLE
feat(folders, page-folders, page-home, foldersviews, users): 보관함 하나 삭제, Swagger 설명 추가

### DIFF
--- a/src/main/java/com/toit/folders/Folders.java
+++ b/src/main/java/com/toit/folders/Folders.java
@@ -116,4 +116,12 @@ public class Folders {
         this.iconIdx = iconIdx;
     }
 
+    /**
+     * Folders 소프트 Delete 실행 시
+     */
+    public void softDelete() {
+        this.status = EntityStatus.DELETED;
+        this.deletedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/toit/folders/FoldersController.java
+++ b/src/main/java/com/toit/folders/FoldersController.java
@@ -1,11 +1,18 @@
 package com.toit.folders;
 
 import com.toit.folders.dto.request.FoldersCreateRequest;
+import com.toit.folders.dto.request.FoldersDeleteRequest;
 import com.toit.folders.dto.request.FoldersUpdateRequest;
 import com.toit.folders.dto.response.FoldersCreateResponse;
+import com.toit.folders.dto.response.FoldersDeleteResponse;
+import com.toit.folders.dto.response.FoldersItemResponse;
 import com.toit.folders.dto.response.FoldersUpdateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,6 +32,10 @@ public class FoldersController {
 
 
     /** Folders 보관함 하나 생성 API */
+    @Operation(
+            summary = "하나의 보관함 생성 - 화면이름 : 보관함 추가, 보관함 추가-아이콘 설정",
+            description = "보관함 생성은 POST입니다."
+    )
     @PostMapping
     public ResponseEntity<FoldersCreateResponse> createFolders(
             @RequestBody FoldersCreateRequest request
@@ -36,11 +47,26 @@ public class FoldersController {
     /**
      * Folders 보관함 수정
      */
+    @Operation(
+            summary = "보관함 수정 - 화면이름 : 보관함-더보기-수정",
+            description = "보관함 이름, 메모, 색상, 아이콘을 수정합니다. 수정은 Patch입니다."
+    )
     @PatchMapping
     public ResponseEntity<FoldersUpdateResponse> updateFolders(
             @RequestBody FoldersUpdateRequest request
             ){
         return ResponseEntity.ok(foldersService.updateFolders(request.getUsersId(), request.getFoldersId(),
                 request.getName(), request.getMemo(), request.getColor(), request.getIconIdx()));
+    }
+
+    @Operation(
+            summary = "보관함 삭제 - 화면이름 : 보관함-더보기-삭제",
+            description = "삭제는 Delete입니다. 삭제 요청을 보낼 시에 Hard 삭제가 되지 않고 Soft 삭제가 일어납니다."
+    )
+    @DeleteMapping
+    public ResponseEntity<FoldersDeleteResponse> deleteFolders(
+            @RequestBody FoldersDeleteRequest request
+    ){
+        return ResponseEntity.ok(foldersService.deleteFolders(request.getUsersId(), request.getFoldersId()));
     }
 }

--- a/src/main/java/com/toit/folders/dto/request/FoldersDeleteRequest.java
+++ b/src/main/java/com/toit/folders/dto/request/FoldersDeleteRequest.java
@@ -1,0 +1,19 @@
+package com.toit.folders.dto.request;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FoldersDeleteRequest {
+    private Long usersId;
+    private Long foldersId;
+
+    public FoldersDeleteRequest(Long usersId, Long foldersId){
+        this.usersId = usersId;
+        this.foldersId = foldersId;
+    }
+}
+

--- a/src/main/java/com/toit/folders/dto/response/FoldersDeleteResponse.java
+++ b/src/main/java/com/toit/folders/dto/response/FoldersDeleteResponse.java
@@ -1,0 +1,39 @@
+package com.toit.folders.dto.response;
+
+import com.toit.common.enums.EntityStatus;
+import com.toit.folders.Folders;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FoldersDeleteResponse {
+    private Long foldersId;
+    private Long usersId;
+    private String name;
+    private String memo;
+    private Boolean isDefault;
+    private String color;
+    private LocalDateTime createdAt;
+    private LocalDateTime deletedAt;
+    private EntityStatus status;
+    private Boolean isFavorite;
+    private Integer iconIdx;
+
+    public FoldersDeleteResponse(Folders folders) {
+        this.foldersId = folders.getFoldersId();
+        this.usersId = folders.getUsers().getUsersId();
+        this.name = folders.getName();
+        this.memo = folders.getMemo();
+        this.isDefault = folders.getIsDefault();
+        this.color = folders.getColor();
+        this.isFavorite = folders.getIsFavorite();
+        this.createdAt = folders.getCreatedAt();
+        this.iconIdx = folders.getIconIdx();
+        this.deletedAt = folders.getDeletedAt();
+        this.status = folders.getStatus();
+    }
+
+}

--- a/src/main/java/com/toit/foldersview/FoldersViewsController.java
+++ b/src/main/java/com/toit/foldersview/FoldersViewsController.java
@@ -2,6 +2,7 @@ package com.toit.foldersview;
 
 import com.toit.foldersview.dto.request.FoldersViewsRequest;
 import com.toit.foldersview.dto.response.FoldersViewsResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +20,10 @@ public class FoldersViewsController {
     /**
      * 최근 본 보관함 이력 업데이트 없으면 리소스 생성
      */
+    @Operation(
+            summary = "최근 본 보관함 생성 API - 화면이름 : 보관함 내부",
+            description = "화면이름이 보관함 내부는 없습니다. 보관함 내부에 들어가실 때 이 API 요청하시면 됩니다."
+    )
     @PostMapping
     public ResponseEntity<FoldersViewsResponse> recordFoldersViews(
             @RequestBody FoldersViewsRequest request

--- a/src/main/java/com/toit/user/UsersController.java
+++ b/src/main/java/com/toit/user/UsersController.java
@@ -2,6 +2,7 @@ package com.toit.user;
 
 import com.toit.user.dto.request.UsersCreateRequest;
 import com.toit.user.dto.response.UsersCreateResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,10 @@ public class UsersController {
     private final UsersService usersService;
 
     /** 사용자 생성 - 카카오 로그인 전 임시 */
+    @Operation(
+            summary = "사용자 생성 API - 화면이름 : X(임시 API)",
+            description = "로그인이 없어 임시로 사용자를 생성해서 해야됩니다."
+    )
     @PostMapping
     public ResponseEntity<UsersCreateResponse> createUser(
             @RequestBody UsersCreateRequest request

--- a/src/main/java/com/toit/view/folders/PageFoldersController.java
+++ b/src/main/java/com/toit/view/folders/PageFoldersController.java
@@ -1,6 +1,7 @@
 package com.toit.view.folders;
 
 import com.toit.view.folders.dto.response.PageFoldersMemoResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,9 @@ public class PageFoldersController {
     private final PageFoldersUseCase pageFoldersUseCase;
 
 
+    @Operation(
+            summary = "보관함 메모 화면 API - 화면이름 : 보관함-더보기-메모보기"
+    )
     @GetMapping("/memo")
     public ResponseEntity<PageFoldersMemoResponse> getOneFoldersMemo(
             @RequestParam("usersId") Long usersId,

--- a/src/main/java/com/toit/view/home/PageHomeViewController.java
+++ b/src/main/java/com/toit/view/home/PageHomeViewController.java
@@ -1,6 +1,7 @@
 package com.toit.view.home;
 
 import com.toit.view.home.dto.response.PageHomeViewResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,9 @@ public class PageHomeViewController {
 
     private final PageHomeUseCase pageHomeUseCase;
 
+    @Operation(
+            summary = "Home 화면 API - 화면이름 : 홈-일정, 홈-일정-연속, 홈-기본, 홈-일정"
+    )
     @GetMapping
     public ResponseEntity<PageHomeViewResponse> getHome(
             @RequestParam("usersId") Long usersId,


### PR DESCRIPTION
## 변경 내용
- folders의 소프트 삭제를 실행시키는 메소드 기능 추가
- folders, page-folders, page-home, foldersviews, users의 Swagger 설명 추가해놓았습니다.
<img width="613" height="56" alt="image" src="https://github.com/user-attachments/assets/ba7cea04-86ee-489b-8d63-070d6cd8db39" />

위 사진과 같이 {기능 설명} - 화면이름 : {화면들} 이렇게 구성했습니다.

<img width="446" height="27" alt="image" src="https://github.com/user-attachments/assets/dc866644-2e5c-47ae-b76c-3bef38fdb84a" />

피그마에서 개발 완료한 화면은 B - 개발완 이렇게 작성했습니다.

Closes: #26 
Closes: #67 
Closes: #36 
Closes: #39 
Closes: #45 
Closes: #62 