### PR TITLE
feat(page-items, items): items 비즈니스 로직에서 링크, 텍스트, 이미지, 파일 각 조회하는 비즈니스 로직 추가, 보관함 내부 화면별 API 기능 추가

### DIFF
--- a/src/main/java/com/toit/items/Items.java
+++ b/src/main/java/com/toit/items/Items.java
@@ -16,10 +16,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 
 @Entity
 @Table(name = "items")
+@Getter
 public class Items {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,7 +50,7 @@ public class Items {
     /**
      * 자료 이름
      * 길이 제한 255
-     * type 형태 LINK(링크 제목), TEXT 일 때 사용
+     * type 형태 LINK(링크 제목), FILE(파일 이름0
      */
     @Column(nullable = true)
     private String name;
@@ -142,7 +144,7 @@ public class Items {
         item.users = users;
         item.storageTarget = StorageTarget.FOLDERS;
         item.storageId = foldersId;
-        item.itemsType = ItemsType.TEXT;
+        item.itemsType = ItemsType.LINK;
         item.textContent = textContent;
         item.linkThumbnail = linkThumbnail;
         item.filePath = filePath;

--- a/src/main/java/com/toit/items/ItemsRepository.java
+++ b/src/main/java/com/toit/items/ItemsRepository.java
@@ -1,7 +1,33 @@
 package com.toit.items;
 
+import com.toit.common.enums.EntityStatus;
+import com.toit.common.enums.ItemsType;
+import com.toit.common.enums.StorageTarget;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ItemsRepository extends JpaRepository<Items, Long>{
 
+    /**
+     * 사용자의 하나의 폴더의 자료 List 조회
+     */
+    @Query("""
+        select i
+        from Items i
+        where i.users.usersId = :usersId
+          and i.storageTarget = :storageTarget
+          and i.storageId = :foldersId
+          and i.itemsType = :itemsType
+          and i.status = :status
+        order by i.createdAt desc
+    """)
+    List<Items> findFoldersItems(
+            @Param("usersId") Long usersId,
+            @Param("storageTarget") StorageTarget storageTarget,
+            @Param("foldersId") Long foldersId,
+            @Param("itemsType") ItemsType itemsType,
+            @Param("status") EntityStatus status
+    );
 }

--- a/src/main/java/com/toit/items/ItemsService.java
+++ b/src/main/java/com/toit/items/ItemsService.java
@@ -1,13 +1,21 @@
 package com.toit.items;
 
 
+import com.toit.common.enums.EntityStatus;
+import com.toit.common.enums.ItemsType;
+import com.toit.common.enums.StorageTarget;
 import com.toit.folders.FoldersService;
+import com.toit.items.dto.response.ItemsFoldersImagesResponse;
+import com.toit.items.dto.response.ItemsFoldersInFilesResponse;
+import com.toit.items.dto.response.ItemsFoldersInLinksResponse;
+import com.toit.items.dto.response.ItemsFoldersInTextsResponse;
 import com.toit.items.dto.response.ItemsTextCreateResponse;
 import com.toit.items.dto.response.itemsLinkCreateResponse;
 import com.toit.items.linkpreview.LinkPreview;
 import com.toit.items.linkpreview.LinkPreviewExtractor;
 import com.toit.user.Users;
 import com.toit.user.UsersService;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -79,5 +87,105 @@ public class ItemsService {
 
 
         return new itemsLinkCreateResponse(usersId, foldersIdList, filePath, preview.getDescription(), preview.getThumbnailUrl(),  preview.getTitle());
+    }
+
+    /**
+     * 하나의 사용자 폴더 내부 링크 조회
+     */
+    public List<ItemsFoldersInLinksResponse> getFoldersLinks(Long usersId, Long foldersId) {
+
+        usersService.findById(usersId);
+        foldersService.findByFoldersIdAndUsers_UsersId(usersId, foldersId);
+        // 링크만 조회
+        List<Items> links = itemsRepository
+                .findFoldersItems(
+                        usersId,
+                        StorageTarget.FOLDERS,
+                        foldersId,
+                        ItemsType.LINK,
+                        EntityStatus.ACTIVE
+                );
+
+        List<ItemsFoldersInLinksResponse> result = new ArrayList<>();
+
+        for (Items item : links) {
+            result.add(new ItemsFoldersInLinksResponse(item));
+        }
+        return result;
+    }
+
+    /**
+     * 하나의 사용자 폴더 내부 텍스트 조회
+     */
+    public List<ItemsFoldersInTextsResponse> getFoldersTexts(Long usersId, Long foldersId) {
+
+        usersService.findById(usersId);
+        foldersService.findByFoldersIdAndUsers_UsersId(usersId, foldersId);
+        // 링크만 조회
+        List<Items> links = itemsRepository
+                .findFoldersItems(
+                        usersId,
+                        StorageTarget.FOLDERS,
+                        foldersId,
+                        ItemsType.TEXT,
+                        EntityStatus.ACTIVE
+                );
+
+        List<ItemsFoldersInTextsResponse> result = new ArrayList<>();
+
+        for (Items item : links) {
+            result.add(new ItemsFoldersInTextsResponse(item));
+        }
+        return result;
+    }
+
+    /**
+     * 하나의 사용자 폴더 내부 이미지 조회
+     */
+    public List<ItemsFoldersImagesResponse> getFoldersImages(Long usersId, Long foldersId) {
+
+        usersService.findById(usersId);
+        foldersService.findByFoldersIdAndUsers_UsersId(usersId, foldersId);
+        // 링크만 조회
+        List<Items> links = itemsRepository
+                .findFoldersItems(
+                        usersId,
+                        StorageTarget.FOLDERS,
+                        foldersId,
+                        ItemsType.IMAGE,
+                        EntityStatus.ACTIVE
+                );
+
+        List<ItemsFoldersImagesResponse> result = new ArrayList<>();
+
+        for (Items item : links) {
+            result.add(new ItemsFoldersImagesResponse(item));
+        }
+        return result;
+    }
+
+    /**
+     * 하나의 사용자 폴더 내부 파일 조회
+     */
+    public List<ItemsFoldersInFilesResponse> getFoldersFiles(Long usersId, Long foldersId) {
+
+        usersService.findById(usersId);
+        foldersService.findByFoldersIdAndUsers_UsersId(usersId, foldersId);
+        // 링크만 조회
+        List<Items> links = itemsRepository
+                .findFoldersItems(
+                        usersId,
+                        StorageTarget.FOLDERS,
+                        foldersId,
+                        ItemsType.FILE,
+                        EntityStatus.ACTIVE
+                );
+
+        List<ItemsFoldersInFilesResponse> result = new ArrayList<>();
+
+        for (Items item : links) {
+            result.add(new ItemsFoldersInFilesResponse(item));
+        }
+        return result;
     }
 }

--- a/src/main/java/com/toit/items/dto/response/ItemsFoldersImagesResponse.java
+++ b/src/main/java/com/toit/items/dto/response/ItemsFoldersImagesResponse.java
@@ -1,0 +1,42 @@
+package com.toit.items.dto.response;
+
+import com.toit.items.Items;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemsFoldersImagesResponse {
+    private Long itemsId;
+
+    /**
+     * 이미지 URL
+     */
+    private String filePath;
+
+    /**
+     * 이미지 메모
+     */
+    private String textContent;
+
+    /**
+     * 자료 생성시간
+     */
+    private LocalDateTime createdAt;
+
+    public ItemsFoldersImagesResponse(Long itemsId, String filePath, String textContent, LocalDateTime createdAt){
+        this.itemsId = itemsId;
+        this.filePath = filePath;
+        this.textContent = textContent;
+        this.createdAt = createdAt;
+    }
+
+    public ItemsFoldersImagesResponse(Items item){
+        this.itemsId = item.getItemsId();
+        this.filePath = item.getFilePath();
+        this.textContent = item.getTextContent();
+        this.createdAt = item.getCreatedAt();
+    }
+}

--- a/src/main/java/com/toit/items/dto/response/ItemsFoldersInFilesResponse.java
+++ b/src/main/java/com/toit/items/dto/response/ItemsFoldersInFilesResponse.java
@@ -1,0 +1,40 @@
+package com.toit.items.dto.response;
+
+import com.toit.items.Items;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemsFoldersInFilesResponse {
+    private Long itemsId;
+
+    /**
+     * 파일 이름
+     */
+    private String name;
+
+    /**
+     * 파일 URL
+     */
+    private String filePath;
+
+    /**
+     * 자료 생성시간
+     */
+    private LocalDateTime createdAt;
+
+    public ItemsFoldersInFilesResponse(Long itemsId, String filePath, LocalDateTime createdAt){
+        this.itemsId = itemsId;
+        this.filePath = filePath;
+        this.createdAt = createdAt;
+    }
+
+    public ItemsFoldersInFilesResponse(Items item){
+        this.itemsId = item.getItemsId();
+        this.filePath = item.getFilePath();
+        this.createdAt = item.getCreatedAt();
+    }
+}

--- a/src/main/java/com/toit/items/dto/response/ItemsFoldersInLinksResponse.java
+++ b/src/main/java/com/toit/items/dto/response/ItemsFoldersInLinksResponse.java
@@ -1,0 +1,55 @@
+package com.toit.items.dto.response;
+
+import com.toit.items.Items;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemsFoldersInLinksResponse {
+    private Long itemsId;
+    /**
+     * 링크 제목
+     */
+    private String name;
+
+    /**
+     * 링크 URL
+     */
+    private String filePath;
+
+    /**
+     * 링크 본문
+     */
+    private String textContent;
+
+    /**
+     * 링크 썸네일
+     */
+    private String linkThumbnail;
+
+    /**
+     * 자료 생성시간
+     */
+    private LocalDateTime createdAt;
+
+    public ItemsFoldersInLinksResponse(Long itemsId, String name, String filePath, String textContent, String linkThumbnail, LocalDateTime createdAt){
+        this.itemsId = itemsId;
+        this.name = name;
+        this.filePath = filePath;
+        this.textContent = textContent;
+        this.linkThumbnail = linkThumbnail;
+        this.createdAt = createdAt;
+    }
+
+    public ItemsFoldersInLinksResponse(Items item){
+        this.itemsId = item.getItemsId();
+        this.name = item.getName();
+        this.filePath = item.getFilePath();
+        this.textContent = item.getTextContent();
+        this.linkThumbnail = item.getLinkThumbnail();
+        this.createdAt = item.getCreatedAt();
+    }
+}

--- a/src/main/java/com/toit/items/dto/response/ItemsFoldersInTextsResponse.java
+++ b/src/main/java/com/toit/items/dto/response/ItemsFoldersInTextsResponse.java
@@ -1,0 +1,34 @@
+package com.toit.items.dto.response;
+
+import com.toit.items.Items;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemsFoldersInTextsResponse {
+    private Long itemsId;
+    /**
+     * 메모 본문
+     */
+    private String textContent;
+
+    /**
+     * 자료 생성시간
+     */
+    private LocalDateTime createdAt;
+
+    public ItemsFoldersInTextsResponse(Long itemsId, String textContent, LocalDateTime createdAt){
+        this.itemsId = itemsId;
+        this.textContent = textContent;
+        this.createdAt = createdAt;
+    }
+
+    public ItemsFoldersInTextsResponse(Items item){
+        this.itemsId = item.getItemsId();
+        this.textContent = item.getTextContent();
+        this.createdAt = item.getCreatedAt();
+    }
+}

--- a/src/main/java/com/toit/view/pageitems/PageItemsController.java
+++ b/src/main/java/com/toit/view/pageitems/PageItemsController.java
@@ -1,0 +1,33 @@
+package com.toit.view.pageitems;
+
+import com.toit.view.pageitems.dto.response.PageFoldersInItemsAllResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Pages - Items", description = "보관함 내부 화면(page) 전용 API")
+@RestController
+@RequestMapping("/page/items")
+@RequiredArgsConstructor
+public class PageItemsController {
+    private final PageItemsUseCase pageItemsUseCase;
+
+    @Operation(
+            summary = "보관함 내부 API - 화면이름 : 보관함-내부-링크, 보관함-내부-노트, 보관함-내부-파일, 보관함-내부-이미지"
+    )
+    @GetMapping
+    public ResponseEntity<PageFoldersInItemsAllResponse> getOneFoldersMemo(
+            @RequestParam("usersId") Long usersId,
+            @RequestParam("foldersId") Long foldersId
+    ) {
+        return ResponseEntity.ok(
+                pageItemsUseCase.getOnFoldersInItemsAll(usersId, foldersId)
+        );
+    }
+
+}

--- a/src/main/java/com/toit/view/pageitems/PageItemsUseCase.java
+++ b/src/main/java/com/toit/view/pageitems/PageItemsUseCase.java
@@ -1,0 +1,7 @@
+package com.toit.view.pageitems;
+
+import com.toit.view.pageitems.dto.response.PageFoldersInItemsAllResponse;
+
+public interface PageItemsUseCase {
+    PageFoldersInItemsAllResponse getOnFoldersInItemsAll(Long usersId, Long foldersId);
+}

--- a/src/main/java/com/toit/view/pageitems/PageItemsUseCaseImpl.java
+++ b/src/main/java/com/toit/view/pageitems/PageItemsUseCaseImpl.java
@@ -1,0 +1,27 @@
+package com.toit.view.pageitems;
+
+import com.toit.items.ItemsService;
+import com.toit.items.dto.response.ItemsFoldersImagesResponse;
+import com.toit.items.dto.response.ItemsFoldersInFilesResponse;
+import com.toit.items.dto.response.ItemsFoldersInLinksResponse;
+import com.toit.items.dto.response.ItemsFoldersInTextsResponse;
+import com.toit.view.pageitems.dto.response.PageFoldersInItemsAllResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PageItemsUseCaseImpl implements PageItemsUseCase{
+    private final ItemsService itemsService;
+
+    @Override
+    public PageFoldersInItemsAllResponse getOnFoldersInItemsAll(Long usersId, Long foldersId) {
+        List<ItemsFoldersInLinksResponse> links = itemsService.getFoldersLinks(usersId, foldersId);
+        List<ItemsFoldersInTextsResponse> texts = itemsService.getFoldersTexts(usersId, foldersId);
+        List<ItemsFoldersInFilesResponse> files = itemsService.getFoldersFiles(usersId, foldersId);
+        List<ItemsFoldersImagesResponse> images = itemsService.getFoldersImages(usersId, foldersId);
+
+        return new PageFoldersInItemsAllResponse(usersId, foldersId, links, texts, files, images);
+    }
+}

--- a/src/main/java/com/toit/view/pageitems/dto/response/PageFoldersInItemsAllResponse.java
+++ b/src/main/java/com/toit/view/pageitems/dto/response/PageFoldersInItemsAllResponse.java
@@ -1,0 +1,35 @@
+package com.toit.view.pageitems.dto.response;
+
+import com.toit.items.dto.response.ItemsFoldersImagesResponse;
+import com.toit.items.dto.response.ItemsFoldersInFilesResponse;
+import com.toit.items.dto.response.ItemsFoldersInLinksResponse;
+import com.toit.items.dto.response.ItemsFoldersInTextsResponse;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PageFoldersInItemsAllResponse {
+    private Long usersId;
+
+    private Long foldersId;
+    private List<ItemsFoldersInLinksResponse> links;
+    private List<ItemsFoldersInTextsResponse> texts;
+
+    private List<ItemsFoldersInFilesResponse> files;
+
+    private List<ItemsFoldersImagesResponse> images;
+
+    public PageFoldersInItemsAllResponse(Long usersId, Long foldersId, List<ItemsFoldersInLinksResponse> links, List<ItemsFoldersInTextsResponse> texts,
+                                         List<ItemsFoldersInFilesResponse> files, List<ItemsFoldersImagesResponse> images){
+        this.usersId = usersId;
+        this.foldersId = foldersId;
+        this.links = links;
+        this.texts = texts;
+        this.files = files;
+        this.images = images;
+    }
+
+}


### PR DESCRIPTION
## 변경 내용
- items Service에서 링크, 텍스트, 이미지, 파일 각각 조회해서 DTO를 만들어주는 메서드 추가
- page-items에서 보관함 내부 화면별 API 기능 추가

Refs: #83 