### PR TITLE
feat(schedules,notification): 일정 상세조회시 색상 받아오기 & 알림 리스트 개수 조회 구현

### DIFF
--- a/src/main/java/com/toit/notification/UserNotificationController.java
+++ b/src/main/java/com/toit/notification/UserNotificationController.java
@@ -1,10 +1,12 @@
 package com.toit.notification;
 
 import com.toit.common.SecurityUtil;
+import com.toit.notification.dto.response.NotificationUnreadCountResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +20,15 @@ public class UserNotificationController {
 
     private final UserNotificationService userNotificationService;
 
-    @Operation(summary = "알림 읽음 처리", description = "사용자 알림 1건을 읽음 상태로 변경합니다.")
+    @Operation(summary = "확인하지 않은 알림 수 조회 API", description = "사용자의 미확인 알림 개수를 조회합니다.")
+    @GetMapping("/unread-count")
+    public ResponseEntity<NotificationUnreadCountResponse> getUnreadCount() {
+        Long usersId = SecurityUtil.getCurrentUserId();
+        long unreadCount = userNotificationService.getUnreadCount(usersId);
+        return ResponseEntity.ok(new NotificationUnreadCountResponse(unreadCount));
+    }
+
+    @Operation(summary = "알림 읽음 처리", description = "사용자의 알림 1건을 읽음 상태로 변경합니다.")
     @PatchMapping("/{notificationId}/read")
     public ResponseEntity<Void> markAsRead(@PathVariable Long notificationId) {
         Long usersId = SecurityUtil.getCurrentUserId();

--- a/src/main/java/com/toit/notification/UserNotificationRepository.java
+++ b/src/main/java/com/toit/notification/UserNotificationRepository.java
@@ -11,5 +11,7 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
 
     List<UserNotification> findAllByUsers_UsersIdOrderByCreatedAtDesc(Long usersId);
 
+    long countByUsers_UsersIdAndIsSentTrueAndIsReadFalse(Long usersId);
+
     Optional<UserNotification> findByNotificationIdAndUsers_UsersId(Long notificationId, Long usersId);
 }

--- a/src/main/java/com/toit/notification/UserNotificationService.java
+++ b/src/main/java/com/toit/notification/UserNotificationService.java
@@ -33,6 +33,11 @@ public class UserNotificationService {
         return userNotificationRepository.findAllByUsers_UsersIdOrderByCreatedAtDesc(usersId);
     }
 
+    public long getUnreadCount(Long usersId) {
+        usersService.findById(usersId);
+        return userNotificationRepository.countByUsers_UsersIdAndIsSentTrueAndIsReadFalse(usersId);
+    }
+
     public void markAsSent(UserNotification notification) {
         notification.markAsSent();
         userNotificationRepository.save(notification);

--- a/src/main/java/com/toit/notification/dto/response/NotificationUnreadCountResponse.java
+++ b/src/main/java/com/toit/notification/dto/response/NotificationUnreadCountResponse.java
@@ -1,0 +1,4 @@
+package com.toit.notification.dto.response;
+
+public record NotificationUnreadCountResponse(long unreadCount) {
+}

--- a/src/main/java/com/toit/schedules/dto/response/ScheduleViewResponse.java
+++ b/src/main/java/com/toit/schedules/dto/response/ScheduleViewResponse.java
@@ -27,6 +27,9 @@ public class ScheduleViewResponse {
     /** 스케줄과 mapping 된 폴더 제목 */
     private String foldersTitle;
 
+    /**스케줄에 선택된 앱 색상*/
+    private String appColor;
+
     /** 스케줄 시간 설정 */
     private Boolean timeSetting;
 
@@ -63,7 +66,7 @@ public class ScheduleViewResponse {
 
     public ScheduleViewResponse(Long schedulesId,
                                 String title, Long foldersId,
-                                String foldersTitle,
+                                String foldersTitle,String appColor,
                                 Boolean timeSetting, LocalDate startDate,
                                 LocalDate endDate, LocalTime startTime,
                                 LocalTime endTime,
@@ -72,6 +75,7 @@ public class ScheduleViewResponse {
         this.title = title;
         this.foldersId = foldersId;
         this.foldersTitle  = foldersTitle;
+        this.appColor = appColor;
         this.timeSetting = timeSetting;
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/com/toit/view/pageschedules/PageSchedulesUseCaseImpl.java
+++ b/src/main/java/com/toit/view/pageschedules/PageSchedulesUseCaseImpl.java
@@ -64,6 +64,7 @@ public class PageSchedulesUseCaseImpl implements PageSchedulesUseCase {
                 schedule.getTitle(),
                 schedule.getFoldersId(),
                 schedule.getFoldersTitle(),
+                schedule.getAppColor(),
                 schedule.getTimeSetting(),
                 schedule.getStartDate(),
                 schedule.getEndDate(),


### PR DESCRIPTION
## 변경 내용
- ScheduleViewResponse 클래스에서 appColor 를 반환할수 있도록 추가
- Notification 에서 읽지 않은 알림의 개수를 조회하는 api 생성

Refs: #211