### PR TITLE
fix(Fcm) : FCM 토큰 중복 처리 및 삭제 정책 추가

### DIFF
--- a/src/main/java/com/toit/fcm/FcmToken.java
+++ b/src/main/java/com/toit/fcm/FcmToken.java
@@ -38,4 +38,9 @@ public class FcmToken {
     public void updateTokenTimestamp() {
         this.lastUpdatedAt = LocalDateTime.now();
     }
+
+    public void updateUser(Users users) {
+        this.users = users;
+        updateTokenTimestamp();
+    }
 }

--- a/src/main/java/com/toit/fcm/FcmTokenController.java
+++ b/src/main/java/com/toit/fcm/FcmTokenController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import com.toit.common.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,5 +33,18 @@ public class FcmTokenController {
     ){
         Long usersId = SecurityUtil.getCurrentUserId();
         return ResponseEntity.ok(fcmTokenService.createFcmToken(usersId, request));
+    }
+
+    @Operation(
+            summary = "FcmToken 삭제",
+            description = "현재 로그인한 사용자의 특정 FCM 토큰을 삭제합니다."
+    )
+    @DeleteMapping()
+    public ResponseEntity<Void> deleteFcmToken(
+            @RequestBody @Valid FcmCreateRequest request
+    ) {
+        Long usersId = SecurityUtil.getCurrentUserId();
+        fcmTokenService.deleteFcmToken(usersId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/toit/fcm/FcmTokenRepository.java
+++ b/src/main/java/com/toit/fcm/FcmTokenRepository.java
@@ -11,6 +11,7 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     // 사용자의 특정 토큰이 이미 있는지 확인 (로그인 시 체크용)
     Optional<FcmToken> findByUsersAndFcmToken(Users users, String token);
 
+    Optional<FcmToken> findByFcmToken(String token);
 
     List<FcmToken> findAllByUsers(Users user);
 //

--- a/src/main/java/com/toit/fcm/FcmTokenService.java
+++ b/src/main/java/com/toit/fcm/FcmTokenService.java
@@ -16,19 +16,30 @@ public class FcmTokenService {
     private final FcmTokenRepository fcmTokenRepository;
     private final UsersService usersService;
 
-
     public FcmCreateResponse createFcmToken(Long usersId, FcmCreateRequest request) {
         Users users = usersService.findById(usersId);
 
-        Optional<FcmToken> existingToken = fcmTokenRepository.findByUsersAndFcmToken(users, request.getFcmToken());
+        Optional<FcmToken> existingToken = fcmTokenRepository.findByFcmToken(request.getFcmToken());
 
         if (existingToken.isPresent()) {
-            existingToken.get().updateTokenTimestamp();
+            FcmToken fcmToken = existingToken.get();
+            if (fcmToken.getUsers().getUsersId().equals(usersId)) {
+                fcmToken.updateTokenTimestamp();
+            } else {
+                fcmToken.updateUser(users);
+            }
+            fcmTokenRepository.save(fcmToken);
             return new FcmCreateResponse(usersId, request.getFcmToken());
         } else {
             FcmToken newToken = new FcmToken(users, request.getFcmToken());
             fcmTokenRepository.save(newToken);
             return new FcmCreateResponse(usersId, request.getFcmToken());
         }
+    }
+
+    public void deleteFcmToken(Long usersId, FcmCreateRequest request) {
+        Users users = usersService.findById(usersId);
+        fcmTokenRepository.findByUsersAndFcmToken(users, request.getFcmToken())
+                .ifPresent(fcmTokenRepository::delete);
     }
 }

--- a/src/main/java/com/toit/fcm/notification/FcmNotificationService.java
+++ b/src/main/java/com/toit/fcm/notification/FcmNotificationService.java
@@ -29,12 +29,10 @@ public class FcmNotificationService {
     private final FcmTokenRepository fcmTokenRepository;
     private final UsersSettingsRepository usersSettingsRepository;
 
-    // 사용자의 앱 알림 설정을 확인하고 등록된 모든 FCM 토큰으로 알림을 보낸다.
     public boolean sendToUser(Users user, FcmNotificationRequest request) {
         return sendToUserInternal(user, request, false);
     }
 
-    // 공지 알림처럼 앱 알림 설정과 무관하게 모든 사용자에게 보낼 때 사용한다.
     public boolean sendToUserIgnoringAppAlarmEnabled(Users user, FcmNotificationRequest request) {
         return sendToUserInternal(user, request, true);
     }
@@ -43,14 +41,14 @@ public class FcmNotificationService {
         if (!ignoreAppAlarmEnabled) {
             UsersSettings usersSettings = usersSettingsRepository.findByUsers_UsersId(user.getUsersId());
             if (usersSettings == null || !Boolean.TRUE.equals(usersSettings.getAppAlarmEnabled())) {
-                log.info("사용자(ID={})는 앱 알림이 비활성화되어 있어 FCM 발송을 건너뜁니다.", user.getUsersId());
+                log.info("사용자 앱 알림이 비활성화되어 FCM 발송을 건너뜁니다. usersId={}", user.getUsersId());
                 return false;
             }
         }
 
         List<FcmToken> tokens = fcmTokenRepository.findAllByUsers(user);
         if (tokens.isEmpty()) {
-            log.warn("사용자(ID={})의 FCM 토큰이 없습니다. 알림 발송을 건너뜁니다.", user.getUsersId());
+            log.warn("사용자의 FCM 토큰이 없어 발송을 건너뜁니다. usersId={}", user.getUsersId());
             return false;
         }
 
@@ -63,7 +61,6 @@ public class FcmNotificationService {
         return isSent;
     }
 
-    // 개별 토큰에 대한 Firebase 메시지를 구성하고 실제 전송한다.
     private boolean sendFcmMessage(FcmToken fcmTokenEntity, FcmNotificationRequest request) {
         try {
             AndroidConfig androidConfig = AndroidConfig.builder()
@@ -101,7 +98,7 @@ public class FcmNotificationService {
             Message firebaseMessage = messageBuilder.build();
 
             FirebaseMessaging.getInstance().send(firebaseMessage);
-            log.info("FCM 전송 성공: UserID={}, Token=...{}",
+            log.info("FCM 전송 성공: usersId={}, token=...{}",
                     fcmTokenEntity.getUsers().getUsersId(),
                     shortenToken(fcmTokenEntity.getFcmToken()));
             return true;
@@ -109,19 +106,28 @@ public class FcmNotificationService {
             MessagingErrorCode errorCode = e.getMessagingErrorCode();
 
             if (errorCode == MessagingErrorCode.UNREGISTERED || errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
-                log.warn("유효하지 않은 토큰 감지 및 제거: {}", fcmTokenEntity.getFcmToken());
+                log.warn("유효하지 않은 FCM 토큰을 제거합니다. usersId={}, token=...{}, errorCode={}",
+                        fcmTokenEntity.getUsers().getUsersId(),
+                        shortenToken(fcmTokenEntity.getFcmToken()),
+                        errorCode);
                 fcmTokenRepository.delete(fcmTokenEntity);
             } else {
-                log.error("FCM 전송 실패(서버 에러): {}", e.getMessage());
+                log.error("FCM 전송 실패: usersId={}, token=...{}, errorCode={}, message={}",
+                        fcmTokenEntity.getUsers().getUsersId(),
+                        shortenToken(fcmTokenEntity.getFcmToken()),
+                        errorCode,
+                        e.getMessage());
             }
             return false;
         } catch (Exception e) {
-            log.error("예상하지 못한 에러: {}", e.getMessage());
+            log.error("FCM 전송 중 예상하지 못한 오류가 발생했습니다. usersId={}, token=...{}, message={}",
+                    fcmTokenEntity.getUsers().getUsersId(),
+                    shortenToken(fcmTokenEntity.getFcmToken()),
+                    e.getMessage());
             return false;
         }
     }
 
-    // 본문이 비어 있으면 기본 문구를 넣고, 너무 길면 자른다.
     private String normalizeBody(String body) {
         if (body == null || body.isBlank()) {
             return "알림이 도착했습니다.";
@@ -129,7 +135,6 @@ public class FcmNotificationService {
         return body.length() > 100 ? body.substring(0, 100) + "..." : body;
     }
 
-    // 로그에 토큰 전체를 남기지 않도록 앞부분만 반환한다.
     private String shortenToken(String token) {
         if (token == null || token.length() <= 10) {
             return token;

--- a/src/main/java/com/toit/user/UsersService.java
+++ b/src/main/java/com/toit/user/UsersService.java
@@ -2,6 +2,7 @@ package com.toit.user;
 
 import com.toit.common.enums.AuthProvider;
 import com.toit.exception.users.UsersNotFoundException;
+import com.toit.fcm.FcmTokenRepository;
 import com.toit.user.dto.request.UsersCreateRequest;
 import com.toit.user.dto.request.UsersUpdateNameRequest;
 import com.toit.user.dto.response.UsersCreateResponse;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class UsersService {
     private final UsersRepository usersRepository;
     private final UsersSettingsRepository usersInfoRepository;
+    private final FcmTokenRepository fcmTokenRepository;
 
 
     public UsersCreateResponse createUser(UsersCreateRequest request) {
@@ -50,6 +52,7 @@ public class UsersService {
 
     public void withdraw(Long usersId) {
         Users user = findById(usersId);
+        fcmTokenRepository.deleteAll(fcmTokenRepository.findAllByUsers(user));
         user.softDelete();
         usersRepository.save(user);
     }


### PR DESCRIPTION
## 변경 내용

- FCM 토큰 저장 시 토큰 기준 전역 조회로 중복 충돌 방지
- 동일 토큰 재등록 시 현재 사용자로 토큰 소유자 갱신
- 로그아웃 시 현재 디바이스 FCM 토큰 삭제 API 추가
- 회원탈퇴 시 해당 사용자의 모든 FCM 토큰 삭제

Refs: #222