### PR TITLE
refactor(fcm) : FCM 푸시 및 일정/인앱 알림 기능 전체 비활성화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ application-local.yml
 
 ### Firebase Key (보안) ###
 src/main/resources/firebase/firebase-key.json
+src/main/resources/firebase/firebase-testserver-key.json
 src/main/resources/data/seed_postgres.sql
 src/main/resources/apple/*.p8
 src/main/resources/cloudfront/private_key.pem
+src/main/resources/cloudfront/cloudfront_private_key_testserver.pem

--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,9 @@ dependencies {
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
 
 	/**
-	 * .env 읽기
+	 * .env 읽기 → application.properties로 대체 (.gitignore로 git 미추적)
 	 */
-	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+	// implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
 	/***
 	 * 	FCM 의존성 추가

--- a/src/main/java/com/toit/auth/AuthController.java
+++ b/src/main/java/com/toit/auth/AuthController.java
@@ -3,12 +3,15 @@ package com.toit.auth;
 
 import com.toit.auth.dto.request.RefreshTokenRequest;
 import com.toit.auth.dto.response.RefreshTokenResponse;
+import com.toit.common.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -47,5 +50,12 @@ public class AuthController {
     @PostMapping("/restore")
     public ResponseEntity<AuthService.LoginTokens> restoreAccount(@RequestParam String restoreToken) {
         return ResponseEntity.ok(authService.restoreAccount(restoreToken));
+    }
+
+    @Operation(summary = "CloudFront Signed Cookie 발급 및 재발급", description = "이미지 조회에 필요한 CloudFront Signed Cookie를 발급합니다. 만료 시 동일 API로 재발급합니다.")
+    @GetMapping("/cloudfront/cookie")
+    public ResponseEntity<Map<String, String>> issueCloudFrontCookie() {
+        Long usersId = SecurityUtil.getCurrentUserId();
+        return ResponseEntity.ok(authService.issueCloudFrontCookies(usersId));
     }
 }

--- a/src/main/java/com/toit/auth/AuthService.java
+++ b/src/main/java/com/toit/auth/AuthService.java
@@ -3,12 +3,15 @@ package com.toit.auth;
 import com.toit.auth.jwt.JwtProvider;
 import com.toit.auth.token.RefreshToken;
 import com.toit.auth.token.RefreshTokenRepository;
+import com.toit.common.cloudfront.CloudFrontSigner;
 import com.toit.exception.auth.InvalidTokenException;
 import com.toit.user.Users;
 import com.toit.user.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +20,7 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UsersRepository usersRepository;
+    private final CloudFrontSigner cloudFrontSigner;
 
     /**
      * 로그인 성공 시 우리 서비스의 Access / Refresh Token을 발급하고,
@@ -88,6 +92,10 @@ public class AuthService {
 
         user.restore();
         return issueLoginTokens(user);
+    }
+
+    public Map<String, String> issueCloudFrontCookies(Long usersId) {
+        return cloudFrontSigner.generateSignedCookies(usersId);
     }
 
     public record LoginTokens(String accessToken, String refreshToken) {

--- a/src/main/java/com/toit/common/S3/attachmentvaildator/AttachmentValidator.java
+++ b/src/main/java/com/toit/common/S3/attachmentvaildator/AttachmentValidator.java
@@ -14,7 +14,7 @@ public class AttachmentValidator {
 
     private static final Logger log = LoggerFactory.getLogger(AttachmentValidator.class);
 
-    private static final long MAX_FILE_SIZE = 10L * 1024 * 1024; // 10MB
+    private static final long MAX_FILE_SIZE = 20L * 1024 * 1024; // 20MB
 
     private static final List<String> ALLOWED_TYPES_FILES = List.of(
             "application/pdf",

--- a/src/main/java/com/toit/common/cloudfront/CloudFrontSigner.java
+++ b/src/main/java/com/toit/common/cloudfront/CloudFrontSigner.java
@@ -1,6 +1,5 @@
 package com.toit.common.cloudfront;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
@@ -8,6 +7,8 @@ import java.security.Signature;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
@@ -28,6 +29,38 @@ public class CloudFrontSigner {
 
     @Value("${cloudfront.ttl-seconds:900}")
     private int ttlSeconds;
+
+    public String getResizeUrl(String objectKey, int width) {
+        return domain + "/resize/" + width + "/" + objectKey;
+    }
+
+    public String getOriginalUrl(String objectKey) {
+        return domain + "/" + objectKey;
+    }
+
+    public Map<String, String> generateSignedCookies(Long userId) {
+        try {
+            log.info("CloudFront Signed Cookie 발급 - keyPairId: {}, domain: {}", keyPairId, domain);
+            long expiry = Instant.now().getEpochSecond() + ttlSeconds;
+            String resourceUrl = domain + "/*";
+
+            String policy = "{\"Statement\":[{\"Resource\":\"" + resourceUrl
+                    + "\",\"Condition\":{\"DateLessThan\":{\"AWS:EpochTime\":" + expiry + "}}}]}";
+
+            String encodedPolicy = toCloudFrontBase64(policy.getBytes(StandardCharsets.UTF_8));
+            byte[] signatureBytes = sign(policy.getBytes(StandardCharsets.UTF_8));
+            String signature = toCloudFrontBase64(signatureBytes);
+
+            Map<String, String> cookies = new LinkedHashMap<>();
+            cookies.put("CloudFront-Policy", encodedPolicy);
+            cookies.put("CloudFront-Signature", signature);
+            cookies.put("CloudFront-Key-Pair-Id", keyPairId);
+            return cookies;
+        } catch (Exception e) {
+            log.error("CloudFront Signed Cookie 생성 실패 - cause: {}", e.getCause() != null ? e.getCause().getMessage() : e.getMessage(), e);
+            throw new RuntimeException("CloudFront Signed Cookie 생성 실패", e);
+        }
+    }
 
     public String generateSignedUrl(String objectKey) {
         try {

--- a/src/main/java/com/toit/fcm/FcmTokenController.java
+++ b/src/main/java/com/toit/fcm/FcmTokenController.java
@@ -22,29 +22,30 @@ public class FcmTokenController {
 
     private final FcmTokenService fcmTokenService ;
 
-    @Operation(
-            summary = "FcmToken 생성 ",
-            description = "Token 생성은 POST입니다."
-    )
-    @PostMapping()
-    @FcmApiDocs
-    public ResponseEntity<FcmCreateResponse> createFcmToken(
-            @RequestBody @Valid FcmCreateRequest request
-    ){
-        Long usersId = SecurityUtil.getCurrentUserId();
-        return ResponseEntity.ok(fcmTokenService.createFcmToken(usersId, request));
-    }
+    // [FCM 비활성화] 토큰 등록/삭제 API 비활성화 (라우팅 제거)
+    // @Operation(
+    //         summary = "FcmToken 생성 ",
+    //         description = "Token 생성은 POST입니다."
+    // )
+    // @PostMapping()
+    // @FcmApiDocs
+    // public ResponseEntity<FcmCreateResponse> createFcmToken(
+    //         @RequestBody @Valid FcmCreateRequest request
+    // ){
+    //     Long usersId = SecurityUtil.getCurrentUserId();
+    //     return ResponseEntity.ok(fcmTokenService.createFcmToken(usersId, request));
+    // }
 
-    @Operation(
-            summary = "FcmToken 삭제",
-            description = "현재 로그인한 사용자의 특정 FCM 토큰을 삭제합니다."
-    )
-    @DeleteMapping()
-    public ResponseEntity<Void> deleteFcmToken(
-            @RequestBody @Valid FcmCreateRequest request
-    ) {
-        Long usersId = SecurityUtil.getCurrentUserId();
-        fcmTokenService.deleteFcmToken(usersId, request);
-        return ResponseEntity.noContent().build();
-    }
+    // @Operation(
+    //         summary = "FcmToken 삭제",
+    //         description = "현재 로그인한 사용자의 특정 FCM 토큰을 삭제합니다."
+    // )
+    // @DeleteMapping()
+    // public ResponseEntity<Void> deleteFcmToken(
+    //         @RequestBody @Valid FcmCreateRequest request
+    // ) {
+    //     Long usersId = SecurityUtil.getCurrentUserId();
+    //     fcmTokenService.deleteFcmToken(usersId, request);
+    //     return ResponseEntity.noContent().build();
+    // }
 }

--- a/src/main/java/com/toit/fcm/config/FcmConfig.java
+++ b/src/main/java/com/toit/fcm/config/FcmConfig.java
@@ -16,14 +16,14 @@ public class FcmConfig {
     @Value("${fcm.key.path}")
     private Resource fcmKeyResource;
 
-    //서버가 시작되는 시점에 firebase 연결을 해줌
-    @PostConstruct
+    // [FCM 비활성화] Firebase 초기화 중단 (키 파일 없어도 서버 기동)
+    // @PostConstruct
     public void init() throws IOException {
-        if (FirebaseApp.getApps().isEmpty()) {
-            FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(GoogleCredentials.fromStream(fcmKeyResource.getInputStream()))
-                    .build();
-            FirebaseApp.initializeApp(options);
-        }
+        // if (FirebaseApp.getApps().isEmpty()) {
+        //     FirebaseOptions options = FirebaseOptions.builder()
+        //             .setCredentials(GoogleCredentials.fromStream(fcmKeyResource.getInputStream()))
+        //             .build();
+        //     FirebaseApp.initializeApp(options);
+        // }
     }
 }

--- a/src/main/java/com/toit/fcm/notification/FcmNotificationService.java
+++ b/src/main/java/com/toit/fcm/notification/FcmNotificationService.java
@@ -29,12 +29,17 @@ public class FcmNotificationService {
     private final FcmTokenRepository fcmTokenRepository;
     private final UsersSettingsRepository usersSettingsRepository;
 
+    // [FCM 비활성화] 발송 중단 — 호출부는 false를 받아 markAsSent를 건너뛴다(알림 DB 기록은 유지).
     public boolean sendToUser(Users user, FcmNotificationRequest request) {
-        return sendToUserInternal(user, request, false);
+        log.info("[FCM 비활성화] sendToUser 건너뜀. usersId={}", user.getUsersId());
+        return false;
+        // return sendToUserInternal(user, request, false);
     }
 
     public boolean sendToUserIgnoringAppAlarmEnabled(Users user, FcmNotificationRequest request) {
-        return sendToUserInternal(user, request, true);
+        log.info("[FCM 비활성화] sendToUserIgnoringAppAlarmEnabled 건너뜀. usersId={}", user.getUsersId());
+        return false;
+        // return sendToUserInternal(user, request, true);
     }
 
     private boolean sendToUserInternal(Users user, FcmNotificationRequest request, boolean ignoreAppAlarmEnabled) {

--- a/src/main/java/com/toit/fcm/notification/NotificationScheduler.java
+++ b/src/main/java/com/toit/fcm/notification/NotificationScheduler.java
@@ -26,51 +26,52 @@ public class NotificationScheduler {
     private final FcmNotificationService fcmNotificationService;
     private final UserNotificationService userNotificationService;
 
-    @Scheduled(cron = "0 * * * * *")
+    // [FCM 비활성화] 정기 알림 발송 스케줄러 중단
+    // @Scheduled(cron = "0 * * * * *")
     public void checkAndSendAlerts() {
-        LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
-        LocalDateTime nextMinute = now.plusMinutes(1);
-
-        log.info("스케줄러 조회 시간: {}", now);
-
-        List<SchedulesAlarm> alarms = schedulesAlarmRepository.findTargetAlarms(now, nextMinute);
-        if (alarms.isEmpty()) return;
-
-        log.info("알림 발송 작업 시작: 총 {}건 예정", alarms.size());
-
-        for (SchedulesAlarm alarm : alarms) {
-            Schedules schedule = alarm.getSchedules();
-            Users user = schedule.getUsers();
-
-            String title = schedule.getTitle();
-            long alarmOffsetMinutes = alarm.getAlarmOffsetMinutes() != null ? alarm.getAlarmOffsetMinutes() : 0L;
-            String body = "일정이 시작되기 " + alarmOffsetMinutes + "분 전입니다.";
-
-            UserNotification notification = userNotificationService.create(
-                    user,
-                    NotificationType.SCHEDULE,
-                    title,
-                    "toit://schedule?id=" + schedule.getSchedulesId(),
-                    schedule.getSchedulesId()
-            );
-
-            boolean isSent = fcmNotificationService.sendToUser(
-                    user,
-                    new FcmNotificationRequest(
-                            title,
-                            body,
-                            "schedule_detail",
-                            notification.getDeeplink(),
-                            notification.getNotificationId()
-                    )
-            );
-
-            if (isSent) {
-                userNotificationService.markAsSent(notification);
-            }
-
-            alarm.markAsSent();
-            schedulesAlarmRepository.save(alarm);
-        }
+        // LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+        // LocalDateTime nextMinute = now.plusMinutes(1);
+        //
+        // log.info("스케줄러 조회 시간: {}", now);
+        //
+        // List<SchedulesAlarm> alarms = schedulesAlarmRepository.findTargetAlarms(now, nextMinute);
+        // if (alarms.isEmpty()) return;
+        //
+        // log.info("알림 발송 작업 시작: 총 {}건 예정", alarms.size());
+        //
+        // for (SchedulesAlarm alarm : alarms) {
+        //     Schedules schedule = alarm.getSchedules();
+        //     Users user = schedule.getUsers();
+        //
+        //     String title = schedule.getTitle();
+        //     long alarmOffsetMinutes = alarm.getAlarmOffsetMinutes() != null ? alarm.getAlarmOffsetMinutes() : 0L;
+        //     String body = "일정이 시작되기 " + alarmOffsetMinutes + "분 전입니다.";
+        //
+        //     UserNotification notification = userNotificationService.create(
+        //             user,
+        //             NotificationType.SCHEDULE,
+        //             title,
+        //             "toit://schedule?id=" + schedule.getSchedulesId(),
+        //             schedule.getSchedulesId()
+        //     );
+        //
+        //     boolean isSent = fcmNotificationService.sendToUser(
+        //             user,
+        //             new FcmNotificationRequest(
+        //                     title,
+        //                     body,
+        //                     "schedule_detail",
+        //                     notification.getDeeplink(),
+        //                     notification.getNotificationId()
+        //             )
+        //     );
+        //
+        //     if (isSent) {
+        //         userNotificationService.markAsSent(notification);
+        //     }
+        //
+        //     alarm.markAsSent();
+        //     schedulesAlarmRepository.save(alarm);
+        // }
     }
 }

--- a/src/main/java/com/toit/feedback/FeedbackService.java
+++ b/src/main/java/com/toit/feedback/FeedbackService.java
@@ -86,27 +86,28 @@ public class FeedbackService {
         feedback.addReply(request.getReply(), adminId);
         feedbackRepository.save(feedback);
 
-        UserNotification notification = userNotificationService.create(
-                feedback.getUsers(),
-                NotificationType.FEEDBACK_REPLY,
-                feedback.getTitle(),
-                "toit://feedback?tab=history",
-                feedback.getFeedbackId()
-        );
-
-        boolean isSent = fcmNotificationService.sendToUser(
-                feedback.getUsers(),
-                new FcmNotificationRequest(
-                        "문의",
-                        "문의하신 내용에 답변이 등록되었습니다.",
-                        "feedback_reply",
-                        "toit://feedback?tab=history",
-                        notification.getNotificationId()
-                )
-        );
-
-        if (isSent) {
-            userNotificationService.markAsSent(notification);
-        }
+        // [FCM 비활성화] 문의 답변 시 인앱 알림 생성 및 FCM 발송 중단
+        // UserNotification notification = userNotificationService.create(
+        //         feedback.getUsers(),
+        //         NotificationType.FEEDBACK_REPLY,
+        //         feedback.getTitle(),
+        //         "toit://feedback?tab=history",
+        //         feedback.getFeedbackId()
+        // );
+        //
+        // boolean isSent = fcmNotificationService.sendToUser(
+        //         feedback.getUsers(),
+        //         new FcmNotificationRequest(
+        //                 "문의",
+        //                 "문의하신 내용에 답변이 등록되었습니다.",
+        //                 "feedback_reply",
+        //                 "toit://feedback?tab=history",
+        //                 notification.getNotificationId()
+        //         )
+        // );
+        //
+        // if (isSent) {
+        //     userNotificationService.markAsSent(notification);
+        // }
     }
 }

--- a/src/main/java/com/toit/items/attachments/AttachMentsController.java
+++ b/src/main/java/com/toit/items/attachments/AttachMentsController.java
@@ -21,8 +21,11 @@ import java.util.List;
 import com.toit.common.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+// import com.toit.items.attachments.dto.response.BenchS3ImageResponse; // [측정 전용] 비활성화
 import org.springframework.web.bind.annotation.DeleteMapping;
+// import org.springframework.web.bind.annotation.GetMapping; // [측정 전용] 비활성화
 import org.springframework.web.bind.annotation.PatchMapping;
+// import org.springframework.web.bind.annotation.PathVariable; // [측정 전용] 비활성화
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,6 +38,16 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class AttachMentsController {
     private final AttachMentsService attachmentsService;
+
+    // [측정 전용] S3 presigned URL 방식 이미지 조회 - p50/p95/p99 비교용 (측정 종료로 비활성화)
+    // @Operation(summary = "[측정 전용] S3 presigned URL 방식 이미지 조회 - p50/p95/p99 비교용, 측정 후 삭제 예정")
+    // @GetMapping("/attachments/images/{folderId}/bench-s3")
+    // public ResponseEntity<List<BenchS3ImageResponse>> getImagesInFoldersS3Bench(
+    //         @PathVariable Long folderId
+    // ) {
+    //     Long usersId = SecurityUtil.getCurrentUserId();
+    //     return ResponseEntity.ok(attachmentsService.getImagesInFoldersS3Bench(usersId, folderId));
+    // }
 
     @Operation(summary = "S3 직접 업로드용 presigned PUT URL 발급 - IMAGE: 최대 3개, FILE: 1개")
     @PostMapping("/attachments/presign")

--- a/src/main/java/com/toit/items/attachments/AttachMentsService.java
+++ b/src/main/java/com/toit/items/attachments/AttachMentsService.java
@@ -175,12 +175,27 @@ public class AttachMentsService {
 
         List<AttachMentsImagesGetInFoldersResponse> attachmentsImagesResponse = new ArrayList<>();
         for (AttachMents a : attachments) {
-            // String signedUrl = cloudFrontSigner.generateSignedUrl(a.getObjectKey());
-            String signedUrl = s3Storage.presignGetUrl(a.getObjectKey(), java.time.Duration.ofDays(7));
-            attachmentsImagesResponse.add(new AttachMentsImagesGetInFoldersResponse(a, signedUrl));
+            // Flutter가 objectKey로 CloudFront URL을 직접 생성한다
+            attachmentsImagesResponse.add(new AttachMentsImagesGetInFoldersResponse(a));
         }
         return attachmentsImagesResponse;
     }
+
+    // [측정 전용] S3 presigned URL 방식 이미지 조회 (p50/p95/p99 비교용, 측정 종료로 비활성화)
+    // public List<com.toit.items.attachments.dto.response.BenchS3ImageResponse> getImagesInFoldersS3Bench(Long usersId, Long foldersId) {
+    //     usersService.findById(usersId);
+    //     foldersService.findByFoldersIdAndUsers_UsersId(usersId, foldersId);
+    //
+    //     List<AttachMents> attachments = attachMenetsRepository
+    //             .findAttachMentsInFolders(usersId, AttachMentsType.IMAGE, foldersId, EntityStatus.ACTIVE);
+    //
+    //     List<com.toit.items.attachments.dto.response.BenchS3ImageResponse> res = new ArrayList<>();
+    //     for (AttachMents a : attachments) {
+    //         String presignedUrl = s3Storage.presignGetUrl(a.getObjectKey(), java.time.Duration.ofDays(7));
+    //         res.add(new com.toit.items.attachments.dto.response.BenchS3ImageResponse(a, presignedUrl));
+    //     }
+    //     return res;
+    // }
 
     /**
      * 이미지 및 파일 삭제
@@ -266,9 +281,7 @@ public class AttachMentsService {
 
         List<AttachMentsImagesGetInFoldersResponse> res = new ArrayList<>(images.size());
         for (AttachMents a : images) {
-            // String signedUrl = cloudFrontSigner.generateSignedUrl(a.getObjectKey());
-            String signedUrl = s3Storage.presignGetUrl(a.getObjectKey(), java.time.Duration.ofDays(7));
-            res.add(new AttachMentsImagesGetInFoldersResponse(a, signedUrl));
+            res.add(new AttachMentsImagesGetInFoldersResponse(a));
         }
         return res;
     }
@@ -343,24 +356,23 @@ public class AttachMentsService {
 
         long totalStart = System.currentTimeMillis();
         long dbSaveMs = 0;
-        long s3ViewUrlMs = 0;
 
         List<AttachMentsConfirmResponse> responses = new ArrayList<>();
 
         for (var file : request.getFiles()) {
-            String presignedUrl = s3Storage.presignGetUrl(file.getObjectKey(), java.time.Duration.ofDays(7));
-
+            // DB의 presignedUrl 컬럼은 더 이상 사용하지 않는다(Flutter가 objectKey로 URL 생성).
+            // 컬럼이 nullable=false이므로 빈 값으로 채운다.
             for (Long folderId : request.getFoldersIdList()) {
                 AttachMents entity;
                 if (request.getAttachmentsType() == AttachMentsType.IMAGE) {
                     entity = AttachMents.createImagesInFolders(
-                            users, folderId, file.getObjectKey(), presignedUrl, file.getContentType(),
+                            users, folderId, file.getObjectKey(), "", file.getContentType(),
                             file.getFileSize(), file.getFileName(), request.getTextContent(),
                             file.getWidth(), file.getHeight()
                     );
                 } else {
                     entity = AttachMents.createFilesInFolders(
-                            users, folderId, file.getObjectKey(), presignedUrl, file.getContentType(),
+                            users, folderId, file.getObjectKey(), "", file.getContentType(),
                             file.getFileSize(), file.getFileName(), request.getTextContent()
                     );
                 }
@@ -369,17 +381,12 @@ public class AttachMentsService {
                 AttachMents saved = attachMentsRepository.save(entity);
                 dbSaveMs += System.currentTimeMillis() - t;
 
-                t = System.currentTimeMillis();
-                // String signedUrl = cloudFrontSigner.generateSignedUrl(saved.getObjectKey());
-                String signedUrl = s3Storage.presignGetUrl(saved.getObjectKey(), java.time.Duration.ofDays(7));
-                s3ViewUrlMs += System.currentTimeMillis() - t;
-
-                responses.add(new AttachMentsConfirmResponse(saved, signedUrl));
+                responses.add(new AttachMentsConfirmResponse(saved));
             }
         }
 
-        log.info("[confirm] total={}ms | dbSave={}ms | s3ViewUrlGenerate={}ms | fileCount={}",
-                System.currentTimeMillis() - totalStart, dbSaveMs, s3ViewUrlMs, request.getFiles().size());
+        log.info("[confirm] total={}ms | dbSave={}ms | fileCount={}",
+                System.currentTimeMillis() - totalStart, dbSaveMs, request.getFiles().size());
 
         return responses;
     }

--- a/src/main/java/com/toit/items/attachments/dto/response/AttachMentsConfirmResponse.java
+++ b/src/main/java/com/toit/items/attachments/dto/response/AttachMentsConfirmResponse.java
@@ -9,8 +9,7 @@ import lombok.Getter;
 public class AttachMentsConfirmResponse {
     private final Long attachmentsId;
     private final AttachMentsType attachmentsType;
-    private final String objectKey;
-    private final String presignedUrl;
+    private final String objectKey;  // Flutter가 이 키로 CloudFront URL을 생성한다
     private final String fileName;
     private final Double attachmentsSize;
     private final String attachmentsExtension;
@@ -19,11 +18,10 @@ public class AttachMentsConfirmResponse {
     private final String textContent;
     private final LocalDateTime createdAt;
 
-    public AttachMentsConfirmResponse(AttachMents attachments, String signedUrl) {
+    public AttachMentsConfirmResponse(AttachMents attachments) {
         this.attachmentsId = attachments.getAttachmentsId();
         this.attachmentsType = attachments.getAttachmentsType();
         this.objectKey = attachments.getObjectKey();
-        this.presignedUrl = signedUrl;
         this.fileName = attachments.getFileName();
         this.attachmentsSize = attachments.getAttachmentsSize();
         this.attachmentsExtension = attachments.getAttachmentsExtension();

--- a/src/main/java/com/toit/items/attachments/dto/response/AttachMentsImagesGetInFoldersResponse.java
+++ b/src/main/java/com/toit/items/attachments/dto/response/AttachMentsImagesGetInFoldersResponse.java
@@ -12,8 +12,7 @@ import lombok.NoArgsConstructor;
 public class AttachMentsImagesGetInFoldersResponse {
     private Long attachmentsId;
     private AttachMentsType attachmentsType;
-    private String objectKey;
-    private String presignedUrl;
+    private String objectKey;  // Flutter가 이 키로 CloudFront URL을 생성한다
     private String attachmentsExtension;
     private Double attachmentsSize;
     private String fileName;
@@ -22,11 +21,10 @@ public class AttachMentsImagesGetInFoldersResponse {
     private String textContent;
     private LocalDateTime createdAt;
 
-    public AttachMentsImagesGetInFoldersResponse(AttachMents attachments, String signedUrl) {
+    public AttachMentsImagesGetInFoldersResponse(AttachMents attachments) {
         this.attachmentsId = attachments.getAttachmentsId();
         this.attachmentsType = attachments.getAttachmentsType();
         this.objectKey = attachments.getObjectKey();
-        this.presignedUrl = signedUrl;
         this.attachmentsExtension = attachments.getAttachmentsExtension();
         this.attachmentsSize = attachments.getAttachmentsSize();
         this.fileName = attachments.getFileName();

--- a/src/main/java/com/toit/items/attachments/dto/response/BenchS3ImageResponse.java
+++ b/src/main/java/com/toit/items/attachments/dto/response/BenchS3ImageResponse.java
@@ -1,0 +1,26 @@
+package com.toit.items.attachments.dto.response;
+
+// [측정 전용] S3 presigned URL 방식 이미지 조회 응답 (p50/p95/p99 비교용, 측정 종료로 비활성화)
+// import com.toit.items.attachments.AttachMents;
+// import lombok.Getter;
+//
+// /**
+//  * [측정 전용] S3 presigned URL 방식 이미지 조회 응답.
+//  * CloudFront 전환 전/후 응답시간(p50/p95/p99) 비교용. 측정 종료 후 삭제 예정.
+//  */
+// @Getter
+// public class BenchS3ImageResponse {
+//     private final Long attachmentsId;
+//     private final String objectKey;
+//     private final String presignedUrl;
+//     private final Double attachmentsSize;
+//     private final String fileName;
+//
+//     public BenchS3ImageResponse(AttachMents attachments, String presignedUrl) {
+//         this.attachmentsId = attachments.getAttachmentsId();
+//         this.objectKey = attachments.getObjectKey();
+//         this.presignedUrl = presignedUrl;
+//         this.attachmentsSize = attachments.getAttachmentsSize();
+//         this.fileName = attachments.getFileName();
+//     }
+// }

--- a/src/main/java/com/toit/noitce/NoticeService.java
+++ b/src/main/java/com/toit/noitce/NoticeService.java
@@ -61,31 +61,32 @@ public class NoticeService {
 
         Notice savedNotice = noticeRepository.save(notice);
 
-        List<Users> users = usersRepository.findAll();
-        List<UserNotification> notifications = userNotificationService.createAll(
-                users,
-                NotificationType.NOTICE,
-                savedNotice.getTitle(),
-                "toit://notice?id=" + savedNotice.getNoticeId(),
-                savedNotice.getNoticeId()
-        );
-
-        for (UserNotification notification : notifications) {
-            boolean isSent = fcmNotificationService.sendToUserIgnoringAppAlarmEnabled(
-                    notification.getUsers(),
-                    new FcmNotificationRequest(
-                            savedNotice.getTitle(),
-                            savedNotice.getContent(),
-                            "notice",
-                            notification.getDeeplink(),
-                            notification.getNotificationId()
-                    )
-            );
-
-            if (isSent) {
-                userNotificationService.markAsSent(notification);
-            }
-        }
+        // [FCM 비활성화] 공지 등록 시 인앱 알림 생성 및 FCM 발송 중단
+        // List<Users> users = usersRepository.findAll();
+        // List<UserNotification> notifications = userNotificationService.createAll(
+        //         users,
+        //         NotificationType.NOTICE,
+        //         savedNotice.getTitle(),
+        //         "toit://notice?id=" + savedNotice.getNoticeId(),
+        //         savedNotice.getNoticeId()
+        // );
+        //
+        // for (UserNotification notification : notifications) {
+        //     boolean isSent = fcmNotificationService.sendToUserIgnoringAppAlarmEnabled(
+        //             notification.getUsers(),
+        //             new FcmNotificationRequest(
+        //                     savedNotice.getTitle(),
+        //                     savedNotice.getContent(),
+        //                     "notice",
+        //                     notification.getDeeplink(),
+        //                     notification.getNotificationId()
+        //             )
+        //     );
+        //
+        //     if (isSent) {
+        //         userNotificationService.markAsSent(notification);
+        //     }
+        // }
     }
 
     // 공지사항 삭제

--- a/src/main/java/com/toit/notification/UserNotificationController.java
+++ b/src/main/java/com/toit/notification/UserNotificationController.java
@@ -20,19 +20,20 @@ public class UserNotificationController {
 
     private final UserNotificationService userNotificationService;
 
-    @Operation(summary = "확인하지 않은 알림 수 조회 API", description = "사용자의 미확인 알림 개수를 조회합니다.")
-    @GetMapping("/unread-count")
-    public ResponseEntity<NotificationUnreadCountResponse> getUnreadCount() {
-        Long usersId = SecurityUtil.getCurrentUserId();
-        long unreadCount = userNotificationService.getUnreadCount(usersId);
-        return ResponseEntity.ok(new NotificationUnreadCountResponse(unreadCount));
-    }
-
-    @Operation(summary = "알림 읽음 처리", description = "사용자의 알림 1건을 읽음 상태로 변경합니다.")
-    @PatchMapping("/{notificationId}/read")
-    public ResponseEntity<Void> markAsRead(@PathVariable Long notificationId) {
-        Long usersId = SecurityUtil.getCurrentUserId();
-        userNotificationService.markAsRead(usersId, notificationId);
-        return ResponseEntity.noContent().build();
-    }
+    // [FCM 비활성화] 인앱 알림 조회/읽음 API 비활성화 (라우팅 제거)
+    // @Operation(summary = "확인하지 않은 알림 수 조회 API", description = "사용자의 미확인 알림 개수를 조회합니다.")
+    // @GetMapping("/unread-count")
+    // public ResponseEntity<NotificationUnreadCountResponse> getUnreadCount() {
+    //     Long usersId = SecurityUtil.getCurrentUserId();
+    //     long unreadCount = userNotificationService.getUnreadCount(usersId);
+    //     return ResponseEntity.ok(new NotificationUnreadCountResponse(unreadCount));
+    // }
+    //
+    // @Operation(summary = "알림 읽음 처리", description = "사용자의 알림 1건을 읽음 상태로 변경합니다.")
+    // @PatchMapping("/{notificationId}/read")
+    // public ResponseEntity<Void> markAsRead(@PathVariable Long notificationId) {
+    //     Long usersId = SecurityUtil.getCurrentUserId();
+    //     userNotificationService.markAsRead(usersId, notificationId);
+    //     return ResponseEntity.noContent().build();
+    // }
 }

--- a/src/main/java/com/toit/schedules/SchedulesService.java
+++ b/src/main/java/com/toit/schedules/SchedulesService.java
@@ -60,13 +60,14 @@ public class SchedulesService {
 
         Folders folders = schedules.getFolders();
 
-        SchedulesAlarm alarm = schedulesAlarmRepository.findBySchedules_SchedulesId(schedulesId)
-                .orElse(null);
-
-        markAlarmAsReadIfNeeded(alarm);
-
-        Boolean alarmState = (alarm != null) ? alarm.getAlarmState() : false;
-        Long alarmOffsetMinutes = (alarm != null) ? alarm.getAlarmOffsetMinutes() : null;
+        // [FCM 비활성화] 일정 알림 조회·읽음 처리 중단 (항상 false/null 반환)
+        // SchedulesAlarm alarm = schedulesAlarmRepository.findBySchedules_SchedulesId(schedulesId)
+        //         .orElse(null);
+        //
+        // markAlarmAsReadIfNeeded(alarm);
+        //
+        // Boolean alarmState = (alarm != null) ? alarm.getAlarmState() : false;
+        // Long alarmOffsetMinutes = (alarm != null) ? alarm.getAlarmOffsetMinutes() : null;
 
         return new ScheduleViewResponse(
                 schedules.getSchedulesId(),
@@ -80,24 +81,25 @@ public class SchedulesService {
                 schedules.getStartTime(),
                 schedules.getEndTime(),
                 schedules.getMemo(),
-                alarmState,
-                alarmOffsetMinutes
+                false,
+                null
         );
     }
 
-    /**
-     * 이미 발송된 일정 알림이 아직 미읽음 상태일 때만 읽음 처리한다.
-     */
-    private void markAlarmAsReadIfNeeded(SchedulesAlarm alarm) {
-        if (alarm == null) {
-            return;
-        }
-        if (!Boolean.TRUE.equals(alarm.getIsSent()) || Boolean.TRUE.equals(alarm.getIsRead())) {
-            return;
-        }
-        alarm.markAsRead();
-        schedulesAlarmRepository.save(alarm);
-    }
+    // [FCM 비활성화] 일정 알림 읽음 처리 중단
+    // /**
+    //  * 이미 발송된 일정 알림이 아직 미읽음 상태일 때만 읽음 처리한다.
+    //  */
+    // private void markAlarmAsReadIfNeeded(SchedulesAlarm alarm) {
+    //     if (alarm == null) {
+    //         return;
+    //     }
+    //     if (!Boolean.TRUE.equals(alarm.getIsSent()) || Boolean.TRUE.equals(alarm.getIsRead())) {
+    //         return;
+    //     }
+    //     alarm.markAsRead();
+    //     schedulesAlarmRepository.save(alarm);
+    // }
 
 
     /***
@@ -200,34 +202,35 @@ public class SchedulesService {
         );
         Schedules savedSchedule = schedulesRepository.save(schedule);
 
-        // 알림 설정이 켜져 있는 경우만 실행
-        if (Boolean.TRUE.equals(request.getAlarmState())) {
-
-            LocalDateTime alarmDateTime;
-
-            if (request.getTimeSetting() && request.getStartTime() != null) {
-                // 1. 일정 시간 설정이 켜져 있는 경우: (시작 시간 - N분 전)
-                LocalDateTime baseDateTime = LocalDateTime.of(request.getStartDate(), request.getStartTime());
-
-                // NullPointerException 방지를 위해 offset이 null이면 0으로 처리 (혹은 기획에 맞게 예외처리)
-                long offset = (request.getAlarmOffsetMinutes() != null) ? request.getAlarmOffsetMinutes() : 0L;
-                alarmDateTime = baseDateTime.minusMinutes(offset);
-
-            } else {
-                // 2. 일정 시간 설정이 꺼져 있는 경우 (종일 일정 등):
-                // 시작 날짜(StartDate)의 오전 9시 0분 정각으로 알림 시간 세팅
-                alarmDateTime = LocalDateTime.of(request.getStartDate(), LocalTime.of(9, 0));
-            }
-
-            // 알림 엔티티 생성 및 저장
-            SchedulesAlarm alarm = new SchedulesAlarm(
-                    savedSchedule,
-                    request.getAlarmState(),
-                    alarmDateTime,
-                    request.getAlarmOffsetMinutes()
-            );
-            schedulesAlarmRepository.save(alarm);
-        }
+        // [FCM 비활성화] 일정 알림 예약(SchedulesAlarm) 생성 중단
+        // // 알림 설정이 켜져 있는 경우만 실행
+        // if (Boolean.TRUE.equals(request.getAlarmState())) {
+        //
+        //     LocalDateTime alarmDateTime;
+        //
+        //     if (request.getTimeSetting() && request.getStartTime() != null) {
+        //         // 1. 일정 시간 설정이 켜져 있는 경우: (시작 시간 - N분 전)
+        //         LocalDateTime baseDateTime = LocalDateTime.of(request.getStartDate(), request.getStartTime());
+        //
+        //         // NullPointerException 방지를 위해 offset이 null이면 0으로 처리 (혹은 기획에 맞게 예외처리)
+        //         long offset = (request.getAlarmOffsetMinutes() != null) ? request.getAlarmOffsetMinutes() : 0L;
+        //         alarmDateTime = baseDateTime.minusMinutes(offset);
+        //
+        //     } else {
+        //         // 2. 일정 시간 설정이 꺼져 있는 경우 (종일 일정 등):
+        //         // 시작 날짜(StartDate)의 오전 9시 0분 정각으로 알림 시간 세팅
+        //         alarmDateTime = LocalDateTime.of(request.getStartDate(), LocalTime.of(9, 0));
+        //     }
+        //
+        //     // 알림 엔티티 생성 및 저장
+        //     SchedulesAlarm alarm = new SchedulesAlarm(
+        //             savedSchedule,
+        //             request.getAlarmState(),
+        //             alarmDateTime,
+        //             request.getAlarmOffsetMinutes()
+        //     );
+        //     schedulesAlarmRepository.save(alarm);
+        // }
 
         return new  SchedulesCreateResponse(savedSchedule.getSchedulesId(), savedSchedule.getTitle());
     }
@@ -267,40 +270,42 @@ public class SchedulesService {
         );
         schedulesRepository.save(schedule);
 
-        // 기존에 설정된 알림이 있는지 조회
-        Optional<SchedulesAlarm> existingAlarm = schedulesAlarmRepository.findBySchedules_SchedulesId(schedule.getSchedulesId());
+        // [FCM 비활성화] 일정 알림 예약(SchedulesAlarm) 갱신/삭제 중단
+        // // 기존에 설정된 알림이 있는지 조회
+        // Optional<SchedulesAlarm> existingAlarm = schedulesAlarmRepository.findBySchedules_SchedulesId(schedule.getSchedulesId());
+        //
+        // if (Boolean.TRUE.equals(request.getAlarmState())) {
+        //     // 알림을 켜는(또는 유지하는) 경우: 알림 시간 재계산
+        //     LocalDateTime alarmDateTime;
+        //     if (request.getTimeSetting() && request.getStartTime() != null) {
+        //         long offset = (request.getAlarmOffsetMinutes() != null) ? request.getAlarmOffsetMinutes() : 0L;
+        //         alarmDateTime = LocalDateTime.of(request.getStartDate(), request.getStartTime()).minusMinutes(offset);
+        //     } else {
+        //         alarmDateTime = LocalDateTime.of(request.getStartDate(), LocalTime.of(9, 0));
+        //     }
+        //
+        //     if (existingAlarm.isPresent()) {
+        //         SchedulesAlarm alarm = existingAlarm.get();
+        //         //  기존 알림이 있음 -> 정보 업데이트 및 상태(isSent, isRead) 초기화
+        //         alarm.updateAlarm(request.getAlarmState(), alarmDateTime, request.getAlarmOffsetMinutes());
+        //         //알림 변경 내용 저장
+        //         schedulesAlarmRepository.save(alarm);
+        //     } else {
+        //         //  기존 알림이 없음 (새로 켬) -> 새로 생성
+        //         SchedulesAlarm newAlarm = new SchedulesAlarm(schedule, request.getAlarmState(), alarmDateTime, request.getAlarmOffsetMinutes());
+        //         schedulesAlarmRepository.save(newAlarm);
+        //     }
+        // } else {
+        //     // 알림을 끄는 경우
+        //     existingAlarm.ifPresent(alarm -> schedulesAlarmRepository.delete(alarm));
+        // }
 
-        if (Boolean.TRUE.equals(request.getAlarmState())) {
-            // 알림을 켜는(또는 유지하는) 경우: 알림 시간 재계산
-            LocalDateTime alarmDateTime;
-            if (request.getTimeSetting() && request.getStartTime() != null) {
-                long offset = (request.getAlarmOffsetMinutes() != null) ? request.getAlarmOffsetMinutes() : 0L;
-                alarmDateTime = LocalDateTime.of(request.getStartDate(), request.getStartTime()).minusMinutes(offset);
-            } else {
-                alarmDateTime = LocalDateTime.of(request.getStartDate(), LocalTime.of(9, 0));
-            }
-
-            if (existingAlarm.isPresent()) {
-                SchedulesAlarm alarm = existingAlarm.get();
-                //  기존 알림이 있음 -> 정보 업데이트 및 상태(isSent, isRead) 초기화
-                alarm.updateAlarm(request.getAlarmState(), alarmDateTime, request.getAlarmOffsetMinutes());
-                //알림 변경 내용 저장
-                schedulesAlarmRepository.save(alarm);
-            } else {
-                //  기존 알림이 없음 (새로 켬) -> 새로 생성
-                SchedulesAlarm newAlarm = new SchedulesAlarm(schedule, request.getAlarmState(), alarmDateTime, request.getAlarmOffsetMinutes());
-                schedulesAlarmRepository.save(newAlarm);
-            }
-        } else {
-            // 알림을 끄는 경우
-            existingAlarm.ifPresent(alarm -> schedulesAlarmRepository.delete(alarm));
-        }
-
-        // request.getAlarmState()가 null일 수 있으므로 안전하게 boolean으로 변환
-        boolean responseAlarmState = Boolean.TRUE.equals(request.getAlarmState());
-
-        // 알림이 꺼져있다면 offset은 무조건 null로 내려주는 것이 프론트엔드 렌더링에 안전합니다.
-        Long responseAlarmOffset = responseAlarmState ? request.getAlarmOffsetMinutes() : null;
+        // [FCM 비활성화] 알림 응답 값 계산 중단 (항상 false/null 반환)
+        // // request.getAlarmState()가 null일 수 있으므로 안전하게 boolean으로 변환
+        // boolean responseAlarmState = Boolean.TRUE.equals(request.getAlarmState());
+        //
+        // // 알림이 꺼져있다면 offset은 무조건 null로 내려주는 것이 프론트엔드 렌더링에 안전합니다.
+        // Long responseAlarmOffset = responseAlarmState ? request.getAlarmOffsetMinutes() : null;
 
 
         return new SchedulesUpdateResponse(
@@ -308,7 +313,7 @@ public class SchedulesService {
                 schedule.getFolders() != null ? schedule.getFolders().getFoldersId() : null,
                 schedule.getTimeSetting(), schedule.getStartDate(), schedule.getEndDate(),
                 schedule.getStartTime(), schedule.getEndTime(), schedule.getMemo(),
-                responseAlarmState,responseAlarmOffset
+                false, null
         );
     }
 

--- a/src/main/java/com/toit/schedules/dto/request/SchedulesCreateRequest.java
+++ b/src/main/java/com/toit/schedules/dto/request/SchedulesCreateRequest.java
@@ -47,11 +47,12 @@ public class SchedulesCreateRequest {
     /** 입력한 메모  */
     private String memo;
 
-    /** 알림 설정 여부 (true: 켬, false: 끔) */
-    private Boolean alarmState;
-
-    /** 몇 분 전 알림인지 (예: 5, 10, 0) - alarmState가 true일 때만 값 존재 */
-    private Long alarmOffsetMinutes;
+    // [FCM 비활성화] 일정 알림 설정 필드 중단
+    // /** 알림 설정 여부 (true: 켬, false: 끔) */
+    // private Boolean alarmState;
+    //
+    // /** 몇 분 전 알림인지 (예: 5, 10, 0) - alarmState가 true일 때만 값 존재 */
+    // private Long alarmOffsetMinutes;
 
 
 }

--- a/src/main/java/com/toit/schedules/dto/request/SchedulesUpdateRequest.java
+++ b/src/main/java/com/toit/schedules/dto/request/SchedulesUpdateRequest.java
@@ -51,18 +51,19 @@ public class SchedulesUpdateRequest {
     /** 메모 */
     private String memo;
 
-    /** 알림 설정 여부 (true: 켬, false: 끔) */
-    private Boolean alarmState;
-
-    /** 몇 분 전 알림인지 (예: 5, 10, 0) - alarmState가 true일 때만 값 존재 */
-    private Long alarmOffsetMinutes;
+    // [FCM 비활성화] 일정 알림 설정 필드 중단
+    // /** 알림 설정 여부 (true: 켬, false: 끔) */
+    // private Boolean alarmState;
+    //
+    // /** 몇 분 전 알림인지 (예: 5, 10, 0) - alarmState가 true일 때만 값 존재 */
+    // private Long alarmOffsetMinutes;
 
 
 
     public SchedulesUpdateRequest(Long schedulesId, String title, String appColor,
                                   Long foldersId, Boolean timeSetting, LocalDate startDate,
                                   LocalDate endDate, LocalTime startTime, LocalTime endTime,
-                                  String memo,Boolean alarmState , Long alarmOffsetMinutes) {
+                                  String memo /* [FCM 비활성화] , Boolean alarmState , Long alarmOffsetMinutes */) {
         this.schedulesId = schedulesId;
         this.title = title;
         this.appColor = appColor;
@@ -73,8 +74,9 @@ public class SchedulesUpdateRequest {
         this.startTime = startTime;
         this.endTime = endTime;
         this.memo = memo;
-        this.alarmState = alarmState;
-        this.alarmOffsetMinutes = alarmOffsetMinutes;
+        // [FCM 비활성화] 알림 필드 할당 중단
+        // this.alarmState = alarmState;
+        // this.alarmOffsetMinutes = alarmOffsetMinutes;
     }
 
 }

--- a/src/main/java/com/toit/schedulesalarm/SchedulesAlarmService.java
+++ b/src/main/java/com/toit/schedulesalarm/SchedulesAlarmService.java
@@ -27,19 +27,21 @@ public class SchedulesAlarmService {
 
     }
 
-    public SchedulesAlarm getAlarmBySchedulesId(Long schedulesId) {
-        return schedulesAlarmRepository.findBySchedules_SchedulesId(schedulesId)
-                .orElse(null);
-    }
+    // [FCM 비활성화] 일정 알림 조회 비활성화
+    // public SchedulesAlarm getAlarmBySchedulesId(Long schedulesId) {
+    //     return schedulesAlarmRepository.findBySchedules_SchedulesId(schedulesId)
+    //             .orElse(null);
+    // }
 
 
-    /***
-     * 푸시 알림 조회
-     */
-    public List<SchedulesAlarm> getAlarmList(Long usersId) {
-        usersService.findById(usersId); // 유저 조회 (예외 case 고려)
-
-        return schedulesAlarmRepository.findSentAlarmsByUsersId(usersId);
-    }
+    // [FCM 비활성화] 푸시 알림 조회 비활성화
+    // /***
+    //  * 푸시 알림 조회
+    //  */
+    // public List<SchedulesAlarm> getAlarmList(Long usersId) {
+    //     usersService.findById(usersId); // 유저 조회 (예외 case 고려)
+    //
+    //     return schedulesAlarmRepository.findSentAlarmsByUsersId(usersId);
+    // }
 
 }

--- a/src/main/java/com/toit/view/pageschedules/PageSchedulesUseCase.java
+++ b/src/main/java/com/toit/view/pageschedules/PageSchedulesUseCase.java
@@ -27,10 +27,11 @@ public interface PageSchedulesUseCase {
      */
     ScheduleViewResponse getScheduleView(Long usersId, Long schedulesId);
 
-    /***
-     * 푸시 알림 조회
-     */
-    PageSchedulesAlarmViewResponse getSchedulesAlarmsView(Long userId);
+    // [FCM 비활성화] 푸시 알림 조회 비활성화
+    // /***
+    //  * 푸시 알림 조회
+    //  */
+    // PageSchedulesAlarmViewResponse getSchedulesAlarmsView(Long userId);
 
 
 

--- a/src/main/java/com/toit/view/pageschedules/PageSchedulesUseCaseImpl.java
+++ b/src/main/java/com/toit/view/pageschedules/PageSchedulesUseCaseImpl.java
@@ -54,10 +54,11 @@ public class PageSchedulesUseCaseImpl implements PageSchedulesUseCase {
     public ScheduleViewResponse getScheduleView(Long usersId, Long schedulesId){
         ScheduleViewResponse schedule = schedulesService.getSchedule(usersId, schedulesId);
 
-        SchedulesAlarm alarm = schedulesAlarmService.getAlarmBySchedulesId(schedulesId);
-
-        Boolean alarmState = (alarm != null) ? alarm.getAlarmState() : false;
-        Long alarmOffsetMinutes = (alarm != null) ? alarm.getAlarmOffsetMinutes() : null;
+        // [FCM 비활성화] 일정 알림 조회 중단 (항상 false/null 반환)
+        // SchedulesAlarm alarm = schedulesAlarmService.getAlarmBySchedulesId(schedulesId);
+        //
+        // Boolean alarmState = (alarm != null) ? alarm.getAlarmState() : false;
+        // Long alarmOffsetMinutes = (alarm != null) ? alarm.getAlarmOffsetMinutes() : null;
 
         return new ScheduleViewResponse(
                 schedule.getSchedulesId(),
@@ -71,30 +72,31 @@ public class PageSchedulesUseCaseImpl implements PageSchedulesUseCase {
                 schedule.getStartTime(),
                 schedule.getEndTime(),
                 schedule.getMemo(),
-                alarmState,
-                alarmOffsetMinutes
+                false,
+                null
         );
     }
 
-    //푸시알림 리스트 조회
-    @Override
-    public PageSchedulesAlarmViewResponse getSchedulesAlarmsView(Long usersId) {
-
-        // 1. 서비스에서 알림 목록(Page) 조회하기
-        List<SchedulesAlarm> alarmPage = schedulesAlarmService.getAlarmList(usersId);
-
-        // 2. Stream과 new 생성자를 조합해서 DTO로 변환
-        List<SchedulesAlarmViewResponse> schedulesAlarms = alarmPage.stream()
-                .map(alarm -> new SchedulesAlarmViewResponse(
-                        alarm.getSchedulesAlarmId(),
-                        alarm.getSchedules().getTitle(),
-                        alarm.getSchedules().getStartDate(),
-                        alarm.getSchedules().getStartTime()
-                ))
-                .collect(Collectors.toList());
-
-        // 3. 만들어두신 최종 껍데기 DTO에 담아서 리턴!
-        return new PageSchedulesAlarmViewResponse(schedulesAlarms);
-    }
+    // [FCM 비활성화] 푸시알림 리스트 조회 비활성화
+    // //푸시알림 리스트 조회
+    // @Override
+    // public PageSchedulesAlarmViewResponse getSchedulesAlarmsView(Long usersId) {
+    //
+    //     // 1. 서비스에서 알림 목록(Page) 조회하기
+    //     List<SchedulesAlarm> alarmPage = schedulesAlarmService.getAlarmList(usersId);
+    //
+    //     // 2. Stream과 new 생성자를 조합해서 DTO로 변환
+    //     List<SchedulesAlarmViewResponse> schedulesAlarms = alarmPage.stream()
+    //             .map(alarm -> new SchedulesAlarmViewResponse(
+    //                     alarm.getSchedulesAlarmId(),
+    //                     alarm.getSchedules().getTitle(),
+    //                     alarm.getSchedules().getStartDate(),
+    //                     alarm.getSchedules().getStartTime()
+    //             ))
+    //             .collect(Collectors.toList());
+    //
+    //     // 3. 만들어두신 최종 껍데기 DTO에 담아서 리턴!
+    //     return new PageSchedulesAlarmViewResponse(schedulesAlarms);
+    // }
 
 }

--- a/src/main/java/com/toit/view/pageschedules/PageSchedulesViewController.java
+++ b/src/main/java/com/toit/view/pageschedules/PageSchedulesViewController.java
@@ -79,15 +79,16 @@ public class PageSchedulesViewController {
 
     }
 
-    /***
-     * 전송된 푸시알림 리스트 조회
-     */
-    @Operation(summary = "SchedulesAlarm 화면 API - 화면이름 : 알림 ")
-    @SchedulesAlarmApiDocs
-    @GetMapping("/alarm")
-    public ResponseEntity<PageSchedulesAlarmViewResponse> getScheduleAlarms(){
-        Long usersId = SecurityUtil.getCurrentUserId();
-        PageSchedulesAlarmViewResponse response = schedulesUseCase.getSchedulesAlarmsView(usersId);
-        return ResponseEntity.ok(response);
-    }
+    // [FCM 비활성화] 전송된 푸시알림 리스트 조회 API 비활성화 (라우팅 제거)
+    // /***
+    //  * 전송된 푸시알림 리스트 조회
+    //  */
+    // @Operation(summary = "SchedulesAlarm 화면 API - 화면이름 : 알림 ")
+    // @SchedulesAlarmApiDocs
+    // @GetMapping("/alarm")
+    // public ResponseEntity<PageSchedulesAlarmViewResponse> getScheduleAlarms(){
+    //     Long usersId = SecurityUtil.getCurrentUserId();
+    //     PageSchedulesAlarmViewResponse response = schedulesUseCase.getSchedulesAlarmsView(usersId);
+    //     return ResponseEntity.ok(response);
+    // }
 }

--- a/src/test/java/com/toit/attachments/AttachmentValidatorTest.java
+++ b/src/test/java/com/toit/attachments/AttachmentValidatorTest.java
@@ -16,26 +16,26 @@ class AttachmentValidatorTest {
     private static final int MB = 1024 * 1024;
 
     @Test
-    @DisplayName("10MB 이하 이미지 파일은 크기 검증을 통과한다")
+    @DisplayName("20MB 이하 이미지 파일은 크기 검증을 통과한다")
     void validateFileSize_shouldPass_whenImageSizeIsUnderLimit() {
         MockMultipartFile image = new MockMultipartFile(
                 "image",
                 "test.png",
                 "image/png",
-                new byte[10 * MB]  // 정확히 10MB
+                new byte[20 * MB]  // 정확히 20MB
         );
 
         assertDoesNotThrow(() -> attachmentValidator.validateFileSize(image.getSize()));
     }
 
     @Test
-    @DisplayName("10MB를 초과한 이미지 파일은 예외를 던진다")
+    @DisplayName("20MB를 초과한 이미지 파일은 예외를 던진다")
     void validateFileSize_shouldThrowException_whenImageSizeExceedsLimit() {
         MockMultipartFile image = new MockMultipartFile(
                 "image",
                 "large.png",
                 "image/png",
-                new byte[10 * MB + 1]  // 10MB + 1byte
+                new byte[20 * MB + 1]  // 20MB + 1byte
         );
 
         assertThrows(FileSizeExceededException.class,
@@ -43,13 +43,13 @@ class AttachmentValidatorTest {
     }
 
     @Test
-    @DisplayName("10MB를 초과한 파일(pdf 등)은 예외를 던진다")
+    @DisplayName("20MB를 초과한 파일(pdf 등)은 예외를 던진다")
     void validateFileSize_shouldThrowException_whenFileSizeExceedsLimit() {
         MockMultipartFile file = new MockMultipartFile(
                 "file",
                 "large.pdf",
                 "application/pdf",
-                new byte[10 * MB + 1]  // 10MB + 1byte
+                new byte[20 * MB + 1]  // 20MB + 1byte
         );
 
         assertThrows(FileSizeExceededException.class,


### PR DESCRIPTION
- FCM 발송 차단: FcmNotificationService 발송 메서드 short-circuit, FcmConfig Firebase 초기화 중단, NotificationScheduler 정기 발송 중단
- FCM 토큰 API 비활성화 (POST/DELETE /fcm)
- 일정 알림 예약(SchedulesAlarm) 생성/수정/조회 중단 및 관련 요청 DTO 필드 주석
- 일정 알림 화면 API 비활성화 (GET /page/schedules/alarm)
- 공지/피드백 인앱 알림 생성 중단 (NoticeService, FeedbackService)
- 인앱 알림 조회/읽음 API 비활성화 (UserNotificationController) 

Refs: #77
Refs: #96
Refs: #103
Refs: #187
Refs: #190
Refs: #201
Refs: #217
Refs: #222
Refs: #83