### PR TITLE
refactor(search) : 통합 검색 N+1 쿼리 제거 및 조회 성능 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,11 @@ out/
 .env
 application-local.yml
 
+### 로그 파일 ###
+logs/
+*.log
+*.log.gz
+
 ### Firebase Key (보안) ###
 src/main/resources/firebase/firebase-key.json
 src/main/resources/firebase/firebase-testserver-key.json

--- a/src/main/java/com/toit/folders/FoldersService.java
+++ b/src/main/java/com/toit/folders/FoldersService.java
@@ -84,8 +84,8 @@ public class FoldersService {
         Users users = usersService.findById(usersId);
 
         long folderCount = foldersRepository.countByUsers_UsersIdAndStatus(usersId, EntityStatus.ACTIVE);
-        if (folderCount >= 20) {
-            throw new IllegalStateException("보관함은 최대 20개까지 생성할 수 있습니다.");
+        if (folderCount >= 100) {
+            throw new IllegalStateException("보관함은 최대 100개까지 생성할 수 있습니다.");
         }
 
         Folders folders = new Folders(

--- a/src/main/java/com/toit/items/attachments/AttachMentsRepository.java
+++ b/src/main/java/com/toit/items/attachments/AttachMentsRepository.java
@@ -83,4 +83,27 @@ public interface AttachMentsRepository extends JpaRepository<AttachMents, Long> 
             @Param("type") AttachMentsType type,
             @Param("keyword") String keyword
     );
+
+    /**
+     * fileName 검색 - 보관함 이름까지 JOIN으로 한 번에 DTO 조회 (N+1 제거)
+     */
+    @Query("""
+        select new com.toit.items.attachments.dto.response.AttachMentsFilesGetInFoldersResponse(
+            a.attachmentsId, a.storageId, a.attachmentsType, a.objectKey,
+            a.attachmentsExtension, a.attachmentsSize, a.fileName, a.createdAt,
+            f.name, a.textContent)
+        from AttachMents a
+        join Folders f on f.foldersId = a.storageId
+        where a.users.usersId = :usersId
+          and a.status = :status
+          and a.attachmentsType = :type
+          and lower(coalesce(a.fileName, '')) like lower(concat('%', :keyword, '%'))
+        order by a.createdAt desc
+    """)
+    List<com.toit.items.attachments.dto.response.AttachMentsFilesGetInFoldersResponse> searchFilesWithFolder(
+            @Param("usersId") Long usersId,
+            @Param("status") EntityStatus status,
+            @Param("type") AttachMentsType type,
+            @Param("keyword") String keyword
+    );
 }

--- a/src/main/java/com/toit/items/attachments/AttachMentsService.java
+++ b/src/main/java/com/toit/items/attachments/AttachMentsService.java
@@ -256,16 +256,9 @@ public class AttachMentsService {
         String k = keyword == null ? "" : keyword.trim();
         if (k.isEmpty()) return List.of();
 
-        List<AttachMents> files = attachMentsRepository.searchByTypeAndFileName(usersId, EntityStatus.ACTIVE, AttachMentsType.FILE, k);
-
-        List<AttachMentsFilesGetInFoldersResponse> res = new ArrayList<>(files.size());
-        for (AttachMents a : files) {
-            String foldersName = foldersService.findById(a.getStorageId()).getName();
-            // String signedUrl = cloudFrontSigner.generateSignedUrl(a.getObjectKey());
-            String signedUrl = s3Storage.presignGetUrl(a.getObjectKey(), java.time.Duration.ofDays(7));
-            res.add(new AttachMentsFilesGetInFoldersResponse(a, foldersName, signedUrl));
-        }
-        return res;
+        // [성능개선] N+1 제거 - 보관함 이름을 JOIN으로 한 번에 가져와 DTO로 직접 조회.
+        // (기존: 행마다 foldersService.findById 호출 = N+1, presigned URL은 목록에서 불필요해 제거)
+        return attachMentsRepository.searchFilesWithFolder(usersId, EntityStatus.ACTIVE, AttachMentsType.FILE, k);
     }
 
     /**

--- a/src/main/java/com/toit/items/attachments/dto/response/AttachMentsFilesGetInFoldersResponse.java
+++ b/src/main/java/com/toit/items/attachments/dto/response/AttachMentsFilesGetInFoldersResponse.java
@@ -39,6 +39,28 @@ public class AttachMentsFilesGetInFoldersResponse {
         this.dayOfWeek = toDayOfWeekKorean(attachments.getCreatedAt());
     }
 
+    /**
+     * DTO 프로젝션 전용 생성자 (N+1 제거 - JOIN으로 보관함 이름까지 한 번에 조회)
+     * select 컬럼 순서/타입과 정확히 일치해야 함.
+     */
+    public AttachMentsFilesGetInFoldersResponse(
+            Long attachmentsId, Long foldersId, AttachMentsType attachmentsType,
+            String objectKey, String attachmentsExtension, Double attachmentsSize,
+            String fileName, LocalDateTime createdAt, String foldersName, String textContent) {
+        this.attachmentsId = attachmentsId;
+        this.foldersId = foldersId;
+        this.attachmentsType = attachmentsType;
+        this.objectKey = objectKey;
+        this.presignedUrl = null;                 // 서명은 목록에서 제거했으므로 null
+        this.attachmentsExtension = attachmentsExtension;
+        this.attachmentsSize = attachmentsSize;
+        this.fileName = fileName;
+        this.createdAt = createdAt;
+        this.foldersName = foldersName;
+        this.textContent = textContent;
+        this.dayOfWeek = toDayOfWeekKorean(createdAt);
+    }
+
     public AttachMentsFilesGetInFoldersResponse(AttachMents attachments, String foldersName, String signedUrl) {
         this.attachmentsId = attachments.getAttachmentsId();
         this.foldersId = attachments.getStorageId();

--- a/src/main/java/com/toit/items/links/LinksRepository.java
+++ b/src/main/java/com/toit/items/links/LinksRepository.java
@@ -43,6 +43,26 @@ public interface LinksRepository extends JpaRepository<Links, Long> {
             @Param("keyword") String keyword
     );
 
+    /**
+     * 링크 검색 - 보관함 이름까지 JOIN으로 한 번에 DTO 조회 (N+1 제거)
+     */
+    @Query("""
+        select new com.toit.items.links.dto.response.LinksGetInFoldersResponse(
+            l.linksId, l.storageId, l.linksName, l.linksUrl, l.linksThumbnail,
+            l.textContent, l.createdAt, f.name)
+        from Links l
+        join Folders f on f.foldersId = l.storageId
+        where l.users.usersId = :usersId
+          and l.status = :status
+          and lower(coalesce(l.linksName, '')) like lower(concat('%', :keyword, '%'))
+        order by l.createdAt desc
+    """)
+    List<com.toit.items.links.dto.response.LinksGetInFoldersResponse> searchLinksWithFolder(
+            @Param("usersId") Long usersId,
+            @Param("status") EntityStatus status,
+            @Param("keyword") String keyword
+    );
+
     long countByStorageIdAndStatus(Long storageId, EntityStatus status);
 
     List<Links> findByStorageIdAndStatus(Long storageId, EntityStatus status);

--- a/src/main/java/com/toit/items/links/LinksService.java
+++ b/src/main/java/com/toit/items/links/LinksService.java
@@ -133,16 +133,8 @@ public class LinksService {
         if (k.isEmpty()) {
             return List.of();
         }
-        List<Links> links =
-                linksRepository.searchLinks(usersId, EntityStatus.ACTIVE, k);
-
-        List<LinksGetInFoldersResponse> responses = new ArrayList<>();
-
-        for (Links link : links) {
-            String foldersName = foldersService.findById(link.getStorageId()).getName();
-            responses.add(new LinksGetInFoldersResponse(link, foldersName));
-        }
-        return responses;
+        // [성능개선] N+1 제거 - 보관함 이름을 JOIN으로 한 번에 가져와 DTO로 직접 조회.
+        return linksRepository.searchLinksWithFolder(usersId, EntityStatus.ACTIVE, k);
     }
 
     public long countByFoldersId(Long foldersId) {

--- a/src/main/java/com/toit/items/links/dto/response/LinksGetInFoldersResponse.java
+++ b/src/main/java/com/toit/items/links/dto/response/LinksGetInFoldersResponse.java
@@ -40,6 +40,24 @@ public class LinksGetInFoldersResponse {
         this.dayOfWeek = toDayOfWeekKorean(links.getCreatedAt());
     }
 
+    /**
+     * DTO 프로젝션 전용 생성자 (N+1 제거 - JOIN으로 보관함 이름까지 한 번에 조회)
+     * select 컬럼 순서/타입과 정확히 일치해야 함.
+     */
+    public LinksGetInFoldersResponse(
+            Long linksId, Long foldersId, String linksName, String linksUrl,
+            String linksThumbnail, String textContent, LocalDateTime createdAt, String foldersName) {
+        this.linksId = linksId;
+        this.foldersId = foldersId;
+        this.linksName = linksName;
+        this.linksUrl = linksUrl;
+        this.linksThumbnail = linksThumbnail;
+        this.textContent = textContent;
+        this.createdAt = createdAt;
+        this.foldersName = foldersName;
+        this.dayOfWeek = toDayOfWeekKorean(createdAt);
+    }
+
     public LinksGetInFoldersResponse(Links links, String foldersName){
         this.linksId = links.getLinksId();
         this.foldersId = links.getStorageId();

--- a/src/main/java/com/toit/items/texts/TextsRepository.java
+++ b/src/main/java/com/toit/items/texts/TextsRepository.java
@@ -41,6 +41,25 @@ public interface TextsRepository extends JpaRepository<Texts, Long> {
             @Param("keyword") String keyword
     );
 
+    /**
+     * 텍스트 검색 - 보관함 이름까지 JOIN으로 한 번에 DTO 조회 (N+1 제거)
+     */
+    @Query("""
+        select new com.toit.items.texts.dto.response.TextsGetInFoldersResponse(
+            t.textsId, t.storageId, t.textContent, t.createdAt, f.name)
+        from Texts t
+        join Folders f on f.foldersId = t.storageId
+        where t.users.usersId = :usersId
+          and t.status = :status
+          and lower(t.textContent) like lower(concat('%', :keyword, '%'))
+        order by t.createdAt desc
+    """)
+    List<com.toit.items.texts.dto.response.TextsGetInFoldersResponse> searchTextsWithFolder(
+            @Param("usersId") Long usersId,
+            @Param("status") EntityStatus status,
+            @Param("keyword") String keyword
+    );
+
     long countByStorageIdAndStatus(Long storageId, EntityStatus status);
 
     List<Texts> findByStorageIdAndStatus(Long storageId, EntityStatus status);

--- a/src/main/java/com/toit/items/texts/TextsService.java
+++ b/src/main/java/com/toit/items/texts/TextsService.java
@@ -110,16 +110,8 @@ public class TextsService {
         if (k.isEmpty()) {
             return List.of();
         }
-        List<Texts> texts =
-                textsRepository.searchByTextContent(usersId, EntityStatus.ACTIVE, k);
-
-        List<TextsGetInFoldersResponse> responses = new ArrayList<>();
-
-        for (Texts text : texts) {
-            String foldersName = foldersService.findById(text.getStorageId()).getName();
-            responses.add(new TextsGetInFoldersResponse(text, foldersName));
-        }
-        return responses;
+        // [성능개선] N+1 제거 - 보관함 이름을 JOIN으로 한 번에 가져와 DTO로 직접 조회.
+        return textsRepository.searchTextsWithFolder(usersId, EntityStatus.ACTIVE, k);
     }
 
     public long countByFoldersId(Long foldersId) {

--- a/src/main/java/com/toit/items/texts/dto/response/TextsGetInFoldersResponse.java
+++ b/src/main/java/com/toit/items/texts/dto/response/TextsGetInFoldersResponse.java
@@ -47,6 +47,20 @@ public class TextsGetInFoldersResponse {
         this.dayOfWeek = toDayOfWeekKorean(createdAt);
     }
 
+    /**
+     * DTO 프로젝션 전용 생성자 (N+1 제거 - JOIN으로 보관함 이름까지 한 번에 조회)
+     * select 컬럼 순서/타입과 정확히 일치해야 함.
+     */
+    public TextsGetInFoldersResponse(
+            Long textsId, Long foldersId, String textContent, LocalDateTime createdAt, String foldersName){
+        this.textsId = textsId;
+        this.foldersId = foldersId;
+        this.textContent = textContent;
+        this.createdAt = createdAt;
+        this.foldersName = foldersName;
+        this.dayOfWeek = toDayOfWeekKorean(createdAt);
+    }
+
     private static String toDayOfWeekKorean(LocalDateTime createdAt) {
         if (createdAt == null) return null;
         ZonedDateTime seoulTime = createdAt.atZone(ZoneId.of("Asia/Seoul"));

--- a/src/main/java/com/toit/view/pagesearch/PageSearchUseCaseImpl.java
+++ b/src/main/java/com/toit/view/pagesearch/PageSearchUseCaseImpl.java
@@ -15,6 +15,7 @@ import com.toit.view.pagesearch.dto.response.PageSearchResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +28,7 @@ public class PageSearchUseCaseImpl implements PageSearchUseCase {
     private final AttachMentsService attachMentsService;
 
     @Override
+    @Transactional(readOnly = true)
     public PageSearchResponse search(Long usersId, String keyword) {
         String k = keyword == null ? "" : keyword.trim();
         if (k.isEmpty()) {

--- a/src/test/java/com/toit/texts/TextsServiceTest.java
+++ b/src/test/java/com/toit/texts/TextsServiceTest.java
@@ -72,7 +72,7 @@ class TextsServiceTest {
         Long usersId = 1L;
         String keyword = "없는키워드";
 
-        when(textsRepository.searchByTextContent(usersId, EntityStatus.ACTIVE, keyword))
+        when(textsRepository.searchTextsWithFolder(usersId, EntityStatus.ACTIVE, keyword))
                 .thenReturn(List.of());
 
         List<TextsGetInFoldersResponse> result = textsService.searchTexts(usersId, keyword);


### PR DESCRIPTION
texts/links/attachments 검색 시 결과 행마다 foldersService.findById로 보관함 이름을 조회하던 N+1 구조를 제거.
JOIN + DTO 프로젝션으로 보관함 이름까지 한 번의 쿼리로 조회하도록 변경.

- TextsRepository.searchTextsWithFolder 등 JOIN 기반 조회 쿼리 추가
- 각 응답 DTO에 프로젝션 전용 생성자 추가 (select 컬럼 순서와 일치)
- 파일 검색: 목록에서 불필요한 presigned URL 생성 제거
- PageSearchUseCaseImpl에 @transactional(readOnly = true) 적용
- 보관함 생성 한도 20 → 100 상향
- 관련 테스트 스텁을 신규 조회 메서드로 수정

Closes: #122 