### PR TITLE
feat(users): 회원 탈퇴 시 관련 데이터 완전 삭제로 전환

### DIFF
--- a/src/main/java/com/toit/auth/token/RefreshTokenRepository.java
+++ b/src/main/java/com/toit/auth/token/RefreshTokenRepository.java
@@ -2,6 +2,9 @@ package com.toit.auth.token;
 
 import com.toit.user.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
@@ -11,4 +14,11 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     // 2. 토큰 문자열(refreshToken) 자체로 찾기
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+    /**
+     * 회원 탈퇴용 - 삭제 시 재발급(reissue)이 차단된다.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from RefreshToken r where r.users.usersId = :usersId")
+    void deleteAllByUsersId(@Param("usersId") Long usersId);
 }

--- a/src/main/java/com/toit/common/S3/config/S3Config.java
+++ b/src/main/java/com/toit/common/S3/config/S3Config.java
@@ -5,15 +5,25 @@ import io.awspring.cloud.s3.ObjectMetadata;
 import io.awspring.cloud.s3.S3Template;
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class S3Config {
 
     private final S3Template s3Template;
+    private final S3Client s3Client;
 
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
@@ -50,6 +60,47 @@ public class S3Config {
 
     public void delete(String objectKey) {
         s3Template.deleteObject(bucket, objectKey);
+    }
+
+    /**
+     * prefix 아래의 모든 객체를 삭제한다. (회원 탈퇴 시 users/{usersId}/ 전체 정리)
+     * <p>
+     * DB의 objectKey 목록이 아니라 prefix를 기준으로 지우므로,
+     * presigned PUT으로 업로드만 되고 confirm 되지 않아 DB에 행이 없는 객체까지 함께 정리된다.
+     * <p>
+     * ListObjectsV2 / DeleteObjects 모두 한 번에 최대 1000건이라 페이지 단위로 그대로 배치 삭제한다.
+     */
+    public void deleteByPrefix(String prefix) {
+        String continuationToken = null;
+        int deletedCount = 0;
+
+        do {
+            ListObjectsV2Response listed = s3Client.listObjectsV2(
+                    ListObjectsV2Request.builder()
+                            .bucket(bucket)
+                            .prefix(prefix)
+                            .continuationToken(continuationToken)
+                            .build()
+            );
+
+            List<ObjectIdentifier> targets = listed.contents().stream()
+                    .map(object -> ObjectIdentifier.builder().key(object.key()).build())
+                    .toList();
+
+            if (!targets.isEmpty()) {
+                s3Client.deleteObjects(
+                        DeleteObjectsRequest.builder()
+                                .bucket(bucket)
+                                .delete(Delete.builder().objects(targets).build())
+                                .build()
+                );
+                deletedCount += targets.size();
+            }
+
+            continuationToken = listed.nextContinuationToken();
+        } while (continuationToken != null);
+
+        log.info("S3 prefix 삭제 완료 - prefix={}, 삭제 객체 수={}", prefix, deletedCount);
     }
 
 }

--- a/src/main/java/com/toit/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/toit/exception/GlobalExceptionHandler.java
@@ -19,6 +19,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -192,6 +194,20 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
         log.warn("[400] IllegalArgumentException: {}", ex.getMessage());
         ErrorResponse response = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * @Valid 검증 실패 (닉네임 길이 초과 등) -> 400
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(FieldError::getDefaultMessage)
+                .orElse("잘못된 요청입니다.");
+        log.warn("[400] MethodArgumentNotValidException: {}", message);
+        ErrorResponse response = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), message);
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/com/toit/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/toit/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import com.toit.exception.items.texts.TextsNotFoundException;
 import com.toit.exception.schedules.ScheduleTimeRangeException;
 import com.toit.exception.schedules.SchedulesNotFoundException;
 import com.toit.exception.schedulesalarm.SchedulesAlarmNotFoundException;
+import com.toit.exception.users.InvalidUsersNameException;
 import com.toit.exception.users.UsersNotFoundException;
 import com.toit.exception.userssettings.UsersSettingsNotFoundException;
 import org.slf4j.Logger;
@@ -52,6 +53,16 @@ public class GlobalExceptionHandler {
         log.warn("[404] UsersNotFoundException: {}", ex.getMessage());
         ErrorResponse response = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    /**
+     * Users -> 400, 닉네임이 비어있거나 최대 길이를 초과함
+     */
+    @ExceptionHandler(InvalidUsersNameException.class)
+    public ResponseEntity<ErrorResponse> InvalidUsersNameException(InvalidUsersNameException ex) {
+        log.warn("[400] InvalidUsersNameException: {}", ex.getMessage());
+        ErrorResponse response = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     /**

--- a/src/main/java/com/toit/exception/users/InvalidUsersNameException.java
+++ b/src/main/java/com/toit/exception/users/InvalidUsersNameException.java
@@ -1,0 +1,9 @@
+package com.toit.exception.users;
+
+public class InvalidUsersNameException extends RuntimeException {
+
+    public InvalidUsersNameException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/toit/fcm/FcmTokenRepository.java
+++ b/src/main/java/com/toit/fcm/FcmTokenRepository.java
@@ -2,6 +2,9 @@ package com.toit.fcm;
 
 import com.toit.user.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,4 +20,11 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 //
 //    // (선택) 특정 사용자의 모든 토큰 삭제 (로그아웃/회원탈퇴 시)
 //    void deleteAllByUser(Users user);
+
+    /**
+     * 회원 탈퇴용
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from FcmToken f where f.users.usersId = :usersId")
+    void deleteAllByUsersId(@Param("usersId") Long usersId);
 }

--- a/src/main/java/com/toit/feedback/Feedback.java
+++ b/src/main/java/com/toit/feedback/Feedback.java
@@ -23,8 +23,11 @@ public class Feedback {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    /**
+     * 작성자. 회원 탈퇴 시 피드백 내용은 운영 자료로 남기고 작성자만 null로 익명화하므로 nullable 이다.
+     */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "users_id", nullable = false)
+    @JoinColumn(name = "users_id")
     private Users users;
 
     @Column(nullable = false, updatable = false)

--- a/src/main/java/com/toit/feedback/FeedbackRepository.java
+++ b/src/main/java/com/toit/feedback/FeedbackRepository.java
@@ -3,6 +3,9 @@ package com.toit.feedback;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -13,5 +16,12 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     Page<Feedback> findAllByUsers_UsersIdOrderByCreatedAtDesc(Long usersId, Pageable pageable);
 
     List<Feedback> findAllByUsers_UsersIdOrderByCreatedAtDesc(Long usersId);
+
+    /**
+     * 회원 탈퇴용 - 피드백 내용은 운영 자료로 남기고 작성자만 익명화한다.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Feedback f set f.users = null where f.users.usersId = :usersId")
+    void anonymizeByUsersId(@Param("usersId") Long usersId);
 
 }

--- a/src/main/java/com/toit/feedback/FeedbackService.java
+++ b/src/main/java/com/toit/feedback/FeedbackService.java
@@ -67,7 +67,8 @@ public class FeedbackService {
         Feedback feedback = feedbackRepository.findById(feedbackId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 피드백입니다."));
 
-        if (!feedback.getUsers().getUsersId().equals(usersId)) {
+        // 탈퇴 회원의 피드백은 작성자가 익명화(null)되어 남으므로 누구도 삭제할 수 없다.
+        if (feedback.getUsers() == null || !feedback.getUsers().getUsersId().equals(usersId)) {
             throw new IllegalArgumentException("본인의 문의만 삭제할 수 있습니다.");
         }
 

--- a/src/main/java/com/toit/feedback/dto/response/FeedbackListResponse.java
+++ b/src/main/java/com/toit/feedback/dto/response/FeedbackListResponse.java
@@ -1,6 +1,7 @@
 package com.toit.feedback.dto.response;
 
 import com.toit.feedback.Feedback;
+import com.toit.user.Users;
 
 import java.time.LocalDateTime;
 
@@ -16,12 +17,14 @@ public record FeedbackListResponse(
         String adminName
 ) {
     public static FeedbackListResponse from(Feedback feedback, String adminName) {
+        // 탈퇴 회원의 피드백은 작성자가 익명화(null)되어 남는다.
+        Users writer = feedback.getUsers();
         return new FeedbackListResponse(
                 feedback.getFeedbackId(),
                 feedback.getTitle(),
                 feedback.getContent(),
-                feedback.getUsers().getEmail(),
-                feedback.getUsers().getName(),
+                writer == null ? null : writer.getEmail(),
+                writer == null ? "탈퇴한 사용자" : writer.getName(),
                 feedback.getCreatedAt(),
                 feedback.getReply(),
                 feedback.getRepliedAt(),

--- a/src/main/java/com/toit/folders/FoldersRepository.java
+++ b/src/main/java/com/toit/folders/FoldersRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -47,4 +48,11 @@ public interface FoldersRepository extends  JpaRepository<Folders, Long>{
             @Param("status") EntityStatus status,
             @Param("keyword") String keyword
     );
+
+    /**
+     * 회원 탈퇴용 - schedules.folders_id FK 때문에 일정 삭제 이후에 호출해야 한다.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Folders f where f.users.usersId = :usersId")
+    void deleteAllByUsersId(@Param("usersId") Long usersId);
 }

--- a/src/main/java/com/toit/items/attachments/AttachMentsRepository.java
+++ b/src/main/java/com/toit/items/attachments/AttachMentsRepository.java
@@ -5,6 +5,7 @@ import com.toit.common.enums.EntityStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -106,4 +107,11 @@ public interface AttachMentsRepository extends JpaRepository<AttachMents, Long> 
             @Param("type") AttachMentsType type,
             @Param("keyword") String keyword
     );
+
+    /**
+     * 회원 탈퇴용 - S3 객체는 prefix 단위로 별도 삭제한다.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from AttachMents a where a.users.usersId = :usersId")
+    void deleteAllByUsersId(@Param("usersId") Long usersId);
 }

--- a/src/main/java/com/toit/items/links/LinksRepository.java
+++ b/src/main/java/com/toit/items/links/LinksRepository.java
@@ -3,6 +3,7 @@ package com.toit.items.links;
 import com.toit.common.enums.EntityStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -66,4 +67,11 @@ public interface LinksRepository extends JpaRepository<Links, Long> {
     long countByStorageIdAndStatus(Long storageId, EntityStatus status);
 
     List<Links> findByStorageIdAndStatus(Long storageId, EntityStatus status);
+
+    /**
+     * 회원 탈퇴용
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Links l where l.users.usersId = :usersId")
+    void deleteAllByUsersId(@Param("usersId") Long usersId);
 }

--- a/src/main/java/com/toit/items/texts/TextsRepository.java
+++ b/src/main/java/com/toit/items/texts/TextsRepository.java
@@ -3,6 +3,7 @@ package com.toit.items.texts;
 import com.toit.common.enums.EntityStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -63,4 +64,11 @@ public interface TextsRepository extends JpaRepository<Texts, Long> {
     long countByStorageIdAndStatus(Long storageId, EntityStatus status);
 
     List<Texts> findByStorageIdAndStatus(Long storageId, EntityStatus status);
+
+    /**
+     * 회원 탈퇴용
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Texts t where t.users.usersId = :usersId")
+    void deleteAllByUsersId(@Param("usersId") Long usersId);
 }

--- a/src/main/java/com/toit/notification/UserNotificationRepository.java
+++ b/src/main/java/com/toit/notification/UserNotificationRepository.java
@@ -1,6 +1,9 @@
 package com.toit.notification;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,4 +17,11 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
     long countByUsers_UsersIdAndIsSentTrueAndIsReadFalse(Long usersId);
 
     Optional<UserNotification> findByNotificationIdAndUsers_UsersId(Long notificationId, Long usersId);
+
+    /**
+     * 회원 탈퇴용
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from UserNotification n where n.users.usersId = :usersId")
+    void deleteAllByUsersId(@Param("usersId") Long usersId);
 }

--- a/src/main/java/com/toit/schedules/SchedulesRepository.java
+++ b/src/main/java/com/toit/schedules/SchedulesRepository.java
@@ -3,6 +3,7 @@ package com.toit.schedules;
 
 import com.toit.common.enums.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -70,4 +71,11 @@ public interface SchedulesRepository extends JpaRepository<Schedules, Long> {
             @Param("keyword") String keyword
     );
 
+
+    /**
+     * 회원 탈퇴용 - schedules_alarm 삭제 이후, folders 삭제 이전에 호출해야 한다.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Schedules s where s.users.usersId = :usersId")
+    void deleteAllByUsersId(@Param("usersId") Long usersId);
 }

--- a/src/main/java/com/toit/schedulesalarm/SchedulesAlarmRepository.java
+++ b/src/main/java/com/toit/schedulesalarm/SchedulesAlarmRepository.java
@@ -2,6 +2,7 @@ package com.toit.schedulesalarm;
 
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -39,5 +40,13 @@ public interface SchedulesAlarmRepository  extends JpaRepository<SchedulesAlarm,
             "ORDER BY a.alarmDateTime DESC" //알림시간을 기준으로 정렬
         )
     List<SchedulesAlarm> findSentAlarmsByUsersId(@Param("usersId") Long usersId);
+
+    /**
+     * 회원 탈퇴용 - schedules_id FK 때문에 일정보다 먼저 삭제해야 한다.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from SchedulesAlarm a "
+            + "where a.schedules in (select s from Schedules s where s.users.usersId = :usersId)")
+    void deleteAllByUsersId(@Param("usersId") Long usersId);
 
 }

--- a/src/main/java/com/toit/user/UsersController.java
+++ b/src/main/java/com/toit/user/UsersController.java
@@ -8,7 +8,6 @@ import com.toit.usersinfo.UsersSettingsService;
 import com.toit.usersinfo.dto.request.UsersSettingsUpdateRequest;
 import com.toit.usersinfo.dto.response.UsersSettingsUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -39,7 +38,7 @@ public class UsersController {
             description = "사용자의 이름(닉네임)을 수정합니다. 닉네임은 최대 10자까지 입력할 수 있습니다."
     )
     @PatchMapping("/name")
-    public ResponseEntity<Void> updateName(@Valid @RequestBody UsersUpdateNameRequest request) {
+    public ResponseEntity<Void> updateName(@RequestBody UsersUpdateNameRequest request) {
         Long usersId = SecurityUtil.getCurrentUserId();
         usersService.updateName(usersId, request);
         return ResponseEntity.noContent().build();
@@ -47,7 +46,8 @@ public class UsersController {
 
     @Operation(
             summary = "회원 탈퇴 API",
-            description = "회원 탈퇴 시 계정이 비활성화됩니다. (Soft Delete)"
+            description = "회원 탈퇴 시 계정과 관련된 모든 데이터(보관함, 자료, 일정, 업로드 파일)가 완전히 삭제됩니다. "
+                    + "복구할 수 없으며, 문의 내역은 작성자를 익명화한 채 운영 자료로 보관됩니다."
     )
     @DeleteMapping("/withdraw")
     public ResponseEntity<Void> withdraw() {

--- a/src/main/java/com/toit/user/UsersController.java
+++ b/src/main/java/com/toit/user/UsersController.java
@@ -8,6 +8,7 @@ import com.toit.usersinfo.UsersSettingsService;
 import com.toit.usersinfo.dto.request.UsersSettingsUpdateRequest;
 import com.toit.usersinfo.dto.response.UsersSettingsUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -35,10 +36,10 @@ public class UsersController {
 
     @Operation(
             summary = "이름 수정 API",
-            description = "사용자의 이름을 수정합니다."
+            description = "사용자의 이름(닉네임)을 수정합니다. 닉네임은 최대 10자까지 입력할 수 있습니다."
     )
     @PatchMapping("/name")
-    public ResponseEntity<Void> updateName(@RequestBody UsersUpdateNameRequest request) {
+    public ResponseEntity<Void> updateName(@Valid @RequestBody UsersUpdateNameRequest request) {
         Long usersId = SecurityUtil.getCurrentUserId();
         usersService.updateName(usersId, request);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/toit/user/UsersService.java
+++ b/src/main/java/com/toit/user/UsersService.java
@@ -1,8 +1,8 @@
 package com.toit.user;
 
 import com.toit.common.enums.AuthProvider;
+import com.toit.exception.users.InvalidUsersNameException;
 import com.toit.exception.users.UsersNotFoundException;
-import com.toit.fcm.FcmTokenRepository;
 import com.toit.user.dto.request.UsersCreateRequest;
 import com.toit.user.dto.request.UsersUpdateNameRequest;
 import com.toit.user.dto.response.UsersCreateResponse;
@@ -18,7 +18,10 @@ import org.springframework.stereotype.Service;
 public class UsersService {
     private final UsersRepository usersRepository;
     private final UsersSettingsRepository usersInfoRepository;
-    private final FcmTokenRepository fcmTokenRepository;
+    private final UsersWithdrawService usersWithdrawService;
+
+    /** 닉네임 최대 길이 */
+    private static final int NAME_MAX_LENGTH = 10;
 
 
     public UsersCreateResponse createUser(UsersCreateRequest request) {
@@ -45,15 +48,33 @@ public class UsersService {
     }
 
     public void updateName(Long usersId, UsersUpdateNameRequest request) {
+        String name = validateName(request.getName());
+
         Users user = findById(usersId);
-        user.updateName(request.getName());
+        user.updateName(name);
         usersRepository.save(user);
     }
 
+    /**
+     * 닉네임 검증 - 앞뒤 공백을 제거한 뒤 검사하고, 정제된 값을 반환한다.
+     * 공백만 입력한 경우도 빈 값으로 처리한다.
+     */
+    private String validateName(String name) {
+        String trimmed = (name == null) ? "" : name.strip();
+
+        if (trimmed.isEmpty()) {
+            throw new InvalidUsersNameException("닉네임을 입력해주세요.");
+        }
+        if (trimmed.length() > NAME_MAX_LENGTH) {
+            throw new InvalidUsersNameException("닉네임은 최대 " + NAME_MAX_LENGTH + "자까지 입력할 수 있습니다.");
+        }
+        return trimmed;
+    }
+
+    /**
+     * 회원 탈퇴 - 사용자와 관련된 모든 데이터를 완전 삭제한다. (복구 불가)
+     */
     public void withdraw(Long usersId) {
-        Users user = findById(usersId);
-        fcmTokenRepository.deleteAll(fcmTokenRepository.findAllByUsers(user));
-        user.softDelete();
-        usersRepository.save(user);
+        usersWithdrawService.withdraw(findById(usersId));
     }
 }

--- a/src/main/java/com/toit/user/UsersWithdrawService.java
+++ b/src/main/java/com/toit/user/UsersWithdrawService.java
@@ -1,0 +1,108 @@
+package com.toit.user;
+
+import com.toit.auth.token.RefreshTokenRepository;
+import com.toit.common.S3.config.S3Config;
+import com.toit.fcm.FcmTokenRepository;
+import com.toit.feedback.FeedbackRepository;
+import com.toit.folders.FoldersRepository;
+import com.toit.items.attachments.AttachMentsRepository;
+import com.toit.items.links.LinksRepository;
+import com.toit.items.texts.TextsRepository;
+import com.toit.notification.UserNotificationRepository;
+import com.toit.schedules.SchedulesRepository;
+import com.toit.schedulesalarm.SchedulesAlarmRepository;
+import com.toit.usersinfo.UsersSettingsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * 회원 탈퇴 시 사용자와 관련된 데이터를 완전 삭제(하드 딜리트)한다.
+ * <p>
+ * 피드백만 예외적으로 내용을 남기고 작성자를 익명화하며,
+ * 탈퇴 통계를 위해 개인정보 없는 {@link WithdrawalLog} 를 남긴다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UsersWithdrawService {
+
+    private final UsersRepository usersRepository;
+    private final WithdrawalLogRepository withdrawalLogRepository;
+    private final SchedulesAlarmRepository schedulesAlarmRepository;
+    private final SchedulesRepository schedulesRepository;
+    private final FoldersRepository foldersRepository;
+    private final TextsRepository textsRepository;
+    private final LinksRepository linksRepository;
+    private final AttachMentsRepository attachMentsRepository;
+    private final UsersSettingsRepository usersSettingsRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final UserNotificationRepository userNotificationRepository;
+    private final FeedbackRepository feedbackRepository;
+    private final S3Config s3Storage;
+
+    @Transactional
+    public void withdraw(Users user) {
+        Long usersId = user.getUsersId();
+
+        // 사용자 레코드가 사라지므로 집계용 정보를 먼저 남긴다.
+        withdrawalLogRepository.save(new WithdrawalLog(user));
+
+        // FK 제약 때문에 순서가 강제된다: 알림 → 일정 → 보관함 → 자료 → 부가정보/토큰 → 사용자
+        schedulesAlarmRepository.deleteAllByUsersId(usersId);
+        schedulesRepository.deleteAllByUsersId(usersId);
+        foldersRepository.deleteAllByUsersId(usersId);
+
+        // 자료(texts/links/attachments)의 storageId 는 FK가 아니라 보관함과 순서 제약이 없다.
+        textsRepository.deleteAllByUsersId(usersId);
+        linksRepository.deleteAllByUsersId(usersId);
+        attachMentsRepository.deleteAllByUsersId(usersId);
+
+        usersSettingsRepository.deleteAllByUsersId(usersId);
+        refreshTokenRepository.deleteAllByUsersId(usersId);
+        fcmTokenRepository.deleteAllByUsersId(usersId);
+        userNotificationRepository.deleteAllByUsersId(usersId);
+
+        // 피드백은 운영 자료로 남기고 작성자만 끊는다.
+        feedbackRepository.anonymizeByUsersId(usersId);
+
+        usersRepository.deleteById(usersId);
+
+        registerS3Cleanup(usersId);
+
+        log.info("회원 탈퇴 완료 - usersId={}", usersId);
+    }
+
+    /**
+     * S3 삭제는 롤백할 수 없으므로 DB 커밋이 확정된 뒤에만 실행한다.
+     * 트랜잭션 안에서 먼저 지우면 이후 롤백 시 파일만 사라지고 레코드가 남아 복구가 불가능해진다.
+     * 반대로 커밋 후에 실패하면 접근 경로가 없는 객체만 남으므로 로그를 남기고 넘어간다.
+     */
+    private void registerS3Cleanup(Long usersId) {
+        String prefix = "users/" + usersId + "/";
+
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            deleteS3Files(prefix);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                deleteS3Files(prefix);
+            }
+        });
+    }
+
+    private void deleteS3Files(String prefix) {
+        try {
+            s3Storage.deleteByPrefix(prefix);
+        } catch (Exception e) {
+            log.error("탈퇴 사용자 S3 파일 삭제 실패 - 수동 정리 필요: prefix={}", prefix, e);
+        }
+    }
+}

--- a/src/main/java/com/toit/user/WithdrawalLog.java
+++ b/src/main/java/com/toit/user/WithdrawalLog.java
@@ -1,0 +1,61 @@
+package com.toit.user;
+
+import com.toit.common.enums.AuthProvider;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 탈퇴 통계용 기록.
+ * 사용자 레코드는 탈퇴 시 완전히 삭제되므로, 집계에 필요한 최소 정보만 남긴다.
+ * 개인 식별 정보(이메일, 이름, 소셜 식별자)는 저장하지 않는다.
+ */
+@Entity
+@Table(name = "withdrawal_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WithdrawalLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long withdrawalLogId;
+
+    /**
+     * 탈퇴한 사용자의 식별자.
+     * 사용자 레코드가 삭제되므로 FK가 아닌 단순 값으로 보관한다.
+     */
+    @Column(nullable = false)
+    private Long usersId;
+
+    /**
+     * 가입 경로 (KAKAO, APPLE)
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AuthProvider authProvider;
+
+    /**
+     * 가입 시각 - 탈퇴까지 걸린 기간 집계용
+     */
+    @Column(nullable = false)
+    private LocalDateTime joinedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime withdrawnAt;
+
+    public WithdrawalLog(Users user) {
+        this.usersId = user.getUsersId();
+        this.authProvider = user.getAuthProvider();
+        this.joinedAt = user.getCreatedAt();
+        this.withdrawnAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/toit/user/WithdrawalLogRepository.java
+++ b/src/main/java/com/toit/user/WithdrawalLogRepository.java
@@ -1,0 +1,8 @@
+package com.toit.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WithdrawalLogRepository extends JpaRepository<WithdrawalLog, Long> {
+}

--- a/src/main/java/com/toit/user/dto/request/UsersUpdateNameRequest.java
+++ b/src/main/java/com/toit/user/dto/request/UsersUpdateNameRequest.java
@@ -1,10 +1,15 @@
 package com.toit.user.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class UsersUpdateNameRequest {
+
+    @NotBlank(message = "닉네임은 필수 값입니다.")
+    @Size(max = 10, message = "닉네임은 최대 10자까지 입력할 수 있습니다.")
     private String name;
 }

--- a/src/main/java/com/toit/user/dto/request/UsersUpdateNameRequest.java
+++ b/src/main/java/com/toit/user/dto/request/UsersUpdateNameRequest.java
@@ -1,15 +1,10 @@
 package com.toit.user.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class UsersUpdateNameRequest {
-
-    @NotBlank(message = "닉네임은 필수 값입니다.")
-    @Size(max = 10, message = "닉네임은 최대 10자까지 입력할 수 있습니다.")
     private String name;
 }

--- a/src/main/java/com/toit/usersinfo/UsersSettingsRepository.java
+++ b/src/main/java/com/toit/usersinfo/UsersSettingsRepository.java
@@ -3,10 +3,20 @@ package com.toit.usersinfo;
 
 import com.toit.user.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UsersSettingsRepository extends JpaRepository<UsersSettings, Long> {
 
     UsersSettings findByUsers_UsersId(Long usersId);
+
+    /**
+     * 회원 탈퇴용
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from UsersSettings us where us.users.usersId = :usersId")
+    void deleteAllByUsersId(@Param("usersId") Long usersId);
 }


### PR DESCRIPTION
## 개요

회원 탈퇴 방식을 soft delete에서 **완전 삭제(하드 딜리트)** 로 전환하고, 닉네임 검증 예외를 전용 예외로 분리합니다.

기존 탈퇴는 `status = DELETED` 로 표시만 하고 보관함/자료/일정과 S3 업로드 파일이 그대로 남아 있었습니다. 이제 탈퇴 시 사용자 관련 데이터를 모두 삭제합니다.

## 변경 사항

### 1. 회원 탈퇴 완전 삭제 (`b24a574`)

**`UsersWithdrawService` 신규 추가** — 리포지토리를 12개 주입해야 해서 `UsersService` 에서 분리했습니다.

FK 제약 때문에 삭제 순서가 강제됩니다.

```
schedules_alarm → schedules → folders
→ texts / links / attachments
→ users_settings / refresh_token / fcm_token / user_notification
→ feedback 익명화 → users
```

- 각 리포지토리에 `@Modifying(clearAutomatically, flushAutomatically)` 벌크 삭제 쿼리 추가
- `SchedulesAlarm` 은 `users_id` 컬럼이 없어 서브쿼리로 처리
- `withdraw()` 에 `@Transactional` 적용 (기존에는 트랜잭션 어노테이션이 아예 없어, FCM 삭제와 상태 변경이 별개 커밋이었음)

**S3 파일 삭제 — `S3Config.deleteByPrefix()` 추가**

`users/{usersId}/` prefix 아래를 `ListObjectsV2` + `DeleteObjects` 로 1000건씩 페이징하며 일괄 삭제합니다.

- DB 의 `objectKey` 목록이 아니라 prefix 기준이라, presigned PUT 으로 업로드만 되고 confirm 되지 않아 DB 에 행이 없는 객체까지 정리됩니다
- **S3 삭제는 롤백이 불가능**하므로 `TransactionSynchronization.afterCommit` 에 등록해 DB 커밋이 확정된 뒤에만 실행합니다. 트랜잭션 안에서 먼저 지우면 이후 롤백 시 파일만 사라지고 레코드가 남아 복구할 수 없습니다
- 삭제 실패 시 예외를 삼키고 prefix 를 에러 로그로 남깁니다 (이미 커밋된 탈퇴를 되돌릴 수 없으므로)

**피드백은 남기고 작성자만 익명화**

운영 자료 성격이라 내용은 보존하고 `users_id` 를 `null` 로 끊습니다. `Feedback.users` 를 nullable 로 전환했고, NPE 가 나던 두 곳을 방어했습니다.

- `FeedbackListResponse` — 익명 피드백은 이메일 `null`, 이름 `"탈퇴한 사용자"`
- `FeedbackService.delete()` — 작성자가 없으면 삭제 거부

**`WithdrawalLog` 신규 추가**

전부 삭제하면 탈퇴 집계가 불가능해지므로, 개인 식별 정보 없이 `usersId`(FK 아님) / 가입 경로 / 가입 시각 / 탈퇴 시각만 남깁니다.

**토큰 무효화** — `refresh_token` 삭제로 재발급(reissue)이 차단됩니다. 일반 사용자는 Bearer 토큰을 쓰므로(쿠키는 `admin_token` 전용) 만료시킬 인증 쿠키는 없습니다. 남은 액세스 토큰은 stateless 라 만료 전까지 유효하지만, 사용자 레코드가 사라져 API 가 404 를 반환합니다.

### 2. 닉네임 검증 전용 예외 (`f14e0e3`)

닉네임 검증 실패를 `IllegalArgumentException` 으로 던지면 다른 도메인의 일반 예외와 같은 핸들러에 묶여 로그에서 구분되지 않습니다. 기존 도메인 예외 규칙(`UsersNotFoundException` 등)에 맞춰 분리했습니다.

- `InvalidUsersNameException` 추가 + `GlobalExceptionHandler` 400 핸들러
- 검증을 Bean Validation 에서 서비스 레이어로 이동 (앞뒤 공백 제거 후 검사 + 정제된 값 반환)

응답 형식(400 + `ErrorResponse`)은 기존과 동일합니다.

## 배포 전 수동 DDL 필요

`ddl-auto=update` 는 **NOT NULL 제약을 완화하지 않습니다.** `Feedback.users_id` 의 nullable 전환이 기존 DB 에 반영되지 않아, 이 DDL 없이는 익명화 UPDATE 가 제약 위반으로 실패합니다.

```sql
ALTER TABLE feedback ALTER COLUMN users_id DROP NOT NULL;
```

확인:

```sql
SELECT column_name, is_nullable FROM information_schema.columns
WHERE table_name = 'feedback' AND column_name = 'users_id';
```

`withdrawal_log` 는 신규 테이블이라 `update` 모드에서 자동 생성됩니다.


## Breaking Change — 탈퇴 후 계정 복구 불가

복구 관련 코드는 **추후 휴지통 기능을 위해 남겨두었으나 현재는 호출되지 않습니다.**

- `AuthService.restoreAccount()`, `POST /api/auth/restore`
- `SocialLoginResult.DELETED_USER` 분기, `AuthSuccessHandler` 의 복구 토큰 발급
- `Users.restore()` / `softDelete()`, `deletedAt`, `EntityStatus.DELETED`

하드 딜리트라 사용자 레코드가 남지 않으므로 로그인 시 `DELETED_USER` 분기를 탈 일이 없습니다.

**재가입은 오히려 개선됩니다.** soft delete 시절에는 `uk_users_provider_identity` 유니크 제약 때문에 같은 소셜 계정으로 새 행을 만들 수 없었지만, 이제 행이 삭제되어 정상적으로 신규 가입됩니다. `fcm_token.fcm_token` 의 unique 제약 충돌도 함께 해소됩니다.

## 테스트

- `./gradlew compileJava` 통과
- `./gradlew test` — 30건 중 29건 통과
- 실패 1건(`PresignedUrlExpiryTest`)은 **본 변경 이전부터 실패하던 기존 건**입니다. 로컬에 `AWS_REGION` 환경변수가 없어 S3 클라이언트 생성이 실패하는 환경 이슈로, `git stash` 로 변경 전 코드에서도 동일하게 실패함을 확인했습니다

## 후속 과제 (이 PR 범위 밖)

- **CloudFront 서명 쿠키 정책 범위** — `CloudFrontSigner.java:45` 의 리소스가 `domain + "/*"` 라 한 사용자의 쿠키로 다른 모든 사용자의 파일에 접근할 수 있습니다. `domain + "/users/{userId}/*"` 로 좁혀야 합니다. CDN 서빙을 되살리기 전 반드시 필요합니다
- **휴지통 기능** — 남겨둔 복구 코드를 기반으로 "삭제 예정" 상태를 재활용
- CloudFront invalidation 은 현재 CDN 이 서빙 경로에서 빠져 있고(주석 처리) 쿠키 만료로 노출 창이 짧아 넣지 않았습니다
