### PR TITLE
feat(link-preview): 링크 프리뷰 전략 분리 및 품질 검증 도입

### DIFF
--- a/src/main/java/com/toit/items/shared/linkpreview/JsoupLinkPreviewStrategy.java
+++ b/src/main/java/com/toit/items/shared/linkpreview/JsoupLinkPreviewStrategy.java
@@ -1,0 +1,309 @@
+package com.toit.items.shared.linkpreview;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * 기본 전략 - HTML을 직접 받아 og 태그를 읽는다.
+ *
+ * <p>대부분의 사이트는 og 태그를 그대로 내려주므로 이 전략으로 충분하다.
+ * 어떤 전략도 처리하지 못한 URL을 받는 최종 폴백이라 {@link #supports}는 항상 참이다.
+ *
+ * <p>og 태그를 얻지 못하면 두 가지를 더 시도한다.
+ * <ol>
+ *   <li>{@code <head>}의 oEmbed 자동 발견 링크 → {@link OEmbedClient}</li>
+ *   <li>다른 User-Agent로 재요청 ({@link #USER_AGENTS})</li>
+ * </ol>
+ *
+ * <p>마지막으로 {@link LinkPreviewQuality}로 결과를 검증한다. 로그인 벽이나 봇 판정에 걸린
+ * 페이지도 200으로 내려오기 때문에, 검증 없이 반환하면 {@code "Instagram"} 같은 값이 저장된다.
+ */
+@Slf4j
+@Order(Ordered.LOWEST_PRECEDENCE)
+@Component
+@RequiredArgsConstructor
+public class JsoupLinkPreviewStrategy implements LinkPreviewStrategy {
+
+    /**
+     * 요청 스레드가 묶이므로 짧게 잡는다. User-Agent를 바꿔 최대 2번 시도하므로
+     * 최악의 경우 이 값의 2배까지 걸린다.
+     */
+    private static final int TIMEOUT_MS = (int) Duration.ofSeconds(4).toMillis();
+
+    /** og 태그는 {@code <head>}에 있어 기본값(2MB)으로도 충분하지만, 무거운 페이지에서 body가 잘리는 것을 방지 */
+    private static final int MAX_BODY_SIZE = 3 * 1024 * 1024;
+
+    /**
+     * 시도 순서대로 나열한 User-Agent.
+     *
+     * <p><b>1) 크롤러 UA를 먼저 쓴다.</b> og 태그는 애초에 링크 프리뷰 크롤러를 위해 만들어진
+     * 규격이라, 알려진 프리뷰 크롤러에게만 og 태그를 내려주는 사이트가 있다. 인스타그램이
+     * 그렇다. 같은 URL에 UA만 바꿔 요청하면 결과가 갈린다(로컬 측정).
+     * <pre>
+     *   facebookexternalhit/1.1                → og 태그 6개
+     *   Twitterbot/1.0                         → og 태그 6개
+     *   Mozilla/5.0 ... Chrome/126             → og 태그 0개
+     * </pre>
+     *
+     * <p><b>2) 브라우저 UA로 폴백한다.</b> 반대로 Cloudflare·Akamai 같은 WAF 뒤에 있는
+     * 사이트는 UA에 {@code bot}이 들어가면 403이나 챌린지 페이지를 준다. 어느 한쪽으로
+     * 고정하면 반대쪽을 놓치므로 둘 다 시도한다. 대다수 사이트는 UA와 무관하게 og 태그를
+     * 주므로 1차에서 끝나고 요청은 한 번만 나간다.
+     *
+     * <p><b>남겨둘 점.</b> 첫 번째 값은 실제로는 Meta 크롤러가 아니므로 사칭이다. 규범에 맞는
+     * 방식은 연락처를 담은 자체 UA({@code toITLinkBot/1.0 (+https://.../bot)})지만, 화이트리스트
+     * 방식인 사이트에서는 알려지지 않은 UA가 우대받지 못해 효과가 없다. 또한 Meta가 요청 IP가
+     * 실제 Meta 대역인지 검증을 추가하면 그날부터 통하지 않는다. 영구적 해결책이 아니라
+     * <b>지금 통하는 방법</b>으로 보고, 실패 시 조용히 폴백하도록 구성했다.
+     */
+    private static final List<String> USER_AGENTS = List.of(
+            "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+                    + "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+    );
+
+    /**
+     * Accept-Language를 보내지 않으면 상대 서버가 요청 IP의 지역으로 언어를 추측한다.
+     * 그 결과 로컬(KR)과 배포 리전에서 서로 다른 언어의 제목/설명이 내려올 수 있어 한국어로 고정한다.
+     */
+    private static final String ACCEPT_LANGUAGE = "ko-KR,ko;q=0.9,en;q=0.8";
+
+    private static final String ACCEPT =
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
+
+    /** oEmbed 자동 발견 링크. @see <a href="https://oembed.com/">oEmbed 스펙</a> */
+    private static final String OEMBED_DISCOVERY_SELECTOR =
+            "link[type=\"application/json+oembed\"]";
+
+    private final OEmbedClient oEmbedClient;
+
+    @Override
+    public boolean supports(String url) {
+        return true; // 최종 폴백
+    }
+
+    @Override
+    public LinkPreview extract(String url) {
+        for (int i = 0; i < USER_AGENTS.size(); i++) {
+            boolean lastAttempt = (i == USER_AGENTS.size() - 1);
+            Attempt attempt = tryExtract(url, USER_AGENTS.get(i), lastAttempt);
+
+            if (attempt.preview() != null) {
+                return attempt.preview();
+            }
+            if (!attempt.worthRetrying()) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 한 개의 User-Agent로 1회 시도한다.
+     *
+     * @param lastAttempt 마지막 시도라면 실패를 {@code warn}으로 남긴다. 중간 시도는 재시도할
+     *                    것이므로 로그를 시끄럽게 만들지 않는다.
+     */
+    private Attempt tryExtract(String url, String userAgent, boolean lastAttempt) {
+        try {
+            Connection.Response response = Jsoup.connect(url)
+                    .userAgent(userAgent)
+                    .header("Accept-Language", ACCEPT_LANGUAGE)
+                    .header("Accept", ACCEPT)
+                    .referrer("https://www.google.com")
+                    .timeout(TIMEOUT_MS)
+                    .maxBodySize(MAX_BODY_SIZE)
+                    .followRedirects(true)
+                    // 4xx/5xx를 예외로 던지지 않고 응답으로 받아, 차단인지 아닌지 로그로 구분한다
+                    .ignoreHttpErrors(true)
+                    .execute();
+
+            // 최종 URL(리다이렉트 반영)
+            String resolvedUrl = response.url().toString();
+
+            if (response.statusCode() >= 400) {
+                // WAF가 봇 UA를 막은 경우일 수 있어 다른 UA로 재시도할 가치가 있다
+                log(lastAttempt, "링크 프리뷰 실패(오류 응답) url={} status={} finalUrl={} ua={}",
+                        url, response.statusCode(), resolvedUrl, shortUa(userAgent));
+                return Attempt.retry();
+            }
+
+            if (!isHtml(response.contentType())) {
+                // PDF/이미지 등은 UA를 바꿔도 결과가 같다
+                log.info("링크 프리뷰 건너뜀(HTML 아님) url={} contentType={}",
+                        url, response.contentType());
+                return Attempt.giveUp();
+            }
+
+            Document doc = response.parse();
+
+            String title = firstNonBlank(
+                    meta(doc, "property", "og:title"),
+                    meta(doc, "name", "twitter:title"),
+                    doc.title()
+            );
+
+            String description = firstNonBlank(
+                    meta(doc, "property", "og:description"),
+                    meta(doc, "name", "twitter:description"),
+                    meta(doc, "name", "description")
+            );
+
+            String thumbnail = firstNonBlank(
+                    meta(doc, "property", "og:image"),
+                    meta(doc, "name", "twitter:image"),
+                    meta(doc, "property", "twitter:image")
+            );
+
+            // og 태그를 못 얻었으면 이 페이지가 oEmbed를 제공하는지 확인한다.
+            // oEmbed는 봇 판정 대상이 아니라, HTML에서 태그가 빠져도 값이 오는 경우가 있다.
+            if (isBlank(title) || isBlank(thumbnail)) {
+                LinkPreview viaOEmbed = tryOEmbedDiscovery(doc, resolvedUrl);
+                if (viaOEmbed != null
+                        && LinkPreviewQuality.judge(viaOEmbed.getTitle(), resolvedUrl).usable()) {
+                    return Attempt.success(viaOEmbed);
+                }
+            }
+
+            if (isBlank(thumbnail)) {
+                // fallback: favicon (프리뷰 실패에 가까운 상태이므로 제목 검증을 통과해야 저장된다)
+                Element icon = doc.selectFirst("link[rel~=(?i)^(shortcut )?icon$]");
+                if (icon != null) {
+                    String faviconHref = icon.hasAttr("href") ? icon.attr("href") : "";
+                    String abs = icon.absUrl("href");
+                    thumbnail = !isBlank(abs) ? abs : absolutize(resolvedUrl, faviconHref);
+                }
+            } else {
+                // meta로 가져온 thumbnail은 content 문자열이라 absUrl이 안 먹음 → 직접 보정
+                thumbnail = absolutize(resolvedUrl, thumbnail);
+            }
+
+            // 200이어도 로그인 벽·차단 페이지를 긁었을 수 있다. 여기서 걸러내지 않으면
+            // 제목이 "Instagram", "- YouTube" 같은 값으로 저장된다.
+            LinkPreviewQuality.Verdict verdict = LinkPreviewQuality.judge(title, resolvedUrl);
+            if (!verdict.usable()) {
+                log(lastAttempt, "링크 프리뷰 품질 미달 url={} finalUrl={} title={} 사유={} ua={}",
+                        url, resolvedUrl, title, verdict, shortUa(userAgent));
+                return Attempt.retry();
+            }
+
+            log.info("링크 프리뷰 성공 url={} finalUrl={} title={} ua={}",
+                    url, resolvedUrl, title, shortUa(userAgent));
+
+            return Attempt.success(new LinkPreview(
+                    resolvedUrl,
+                    LinkPreviewStrategy.sanitizeTitle(title),
+                    LinkPreviewStrategy.sanitizeDescription(description),
+                    LinkPreviewStrategy.sanitizeUrl(thumbnail)));
+
+        } catch (Exception e) {
+            // 타임아웃·연결 실패는 UA를 바꿔도 마찬가지이고, 재시도하면 대기 시간만 2배가 된다
+            log.warn("링크 프리뷰 실패 url={} ua={} cause={}: {}",
+                    url, shortUa(userAgent), e.getClass().getSimpleName(), e.getMessage());
+            return Attempt.giveUp();
+        }
+    }
+
+    /** {@code <head>}에 oEmbed 자동 발견 링크가 있으면 호출한다. */
+    private LinkPreview tryOEmbedDiscovery(Document doc, String resolvedUrl) {
+        Element link = doc.selectFirst(OEMBED_DISCOVERY_SELECTOR);
+        if (link == null) {
+            return null;
+        }
+        String endpoint = link.absUrl("href");
+        if (isBlank(endpoint)) {
+            return null;
+        }
+        return oEmbedClient.fetch(endpoint, resolvedUrl);
+    }
+
+    /** 마지막 시도의 실패만 {@code warn}으로 남긴다. 중간 실패는 재시도하므로 {@code info}. */
+    private static void log(boolean lastAttempt, String message, Object... args) {
+        if (lastAttempt) {
+            log.warn(message, args);
+        } else {
+            log.info(message, args);
+        }
+    }
+
+    /** 로그에 UA 전체를 남기면 한 줄이 너무 길어져 앞부분만 남긴다. */
+    private static String shortUa(String userAgent) {
+        int cut = userAgent.indexOf(' ');
+        return (cut > 0) ? userAgent.substring(0, cut) : userAgent;
+    }
+
+    /** Content-Type이 HTML 계열일 때만 파싱한다. (PDF/이미지 링크 등은 프리뷰 대상이 아님) */
+    private static boolean isHtml(String contentType) {
+        if (contentType == null || contentType.isBlank()) {
+            return true; // 헤더가 없으면 일단 시도
+        }
+        String ct = contentType.toLowerCase();
+        return ct.startsWith("text/html") || ct.startsWith("application/xhtml");
+    }
+
+    private static String meta(Document doc, String attrKey, String attrValue) {
+        Element el = doc.selectFirst("meta[" + attrKey + "=" + attrValue + "]");
+        if (el == null) return null;
+        String content = el.attr("content");
+        return isBlank(content) ? null : content.trim();
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String v : values) {
+            if (!isBlank(v)) return v.trim();
+        }
+        return null;
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+
+    private static String absolutize(String baseUrl, String maybeRelative) {
+        if (isBlank(maybeRelative)) return null;
+        String v = maybeRelative.trim();
+        // 이미 절대경로면 그대로
+        if (v.startsWith("http://") || v.startsWith("https://")) return v;
+
+        try {
+            URI base = URI.create(baseUrl);
+            return base.resolve(v).toString();
+        } catch (Exception e) {
+            return v; // 최후의 fallback
+        }
+    }
+
+    /**
+     * 한 번의 시도 결과.
+     *
+     * @param preview       성공한 프리뷰. 실패면 {@code null}
+     * @param worthRetrying 다른 User-Agent로 재시도할 가치가 있는지
+     */
+    private record Attempt(LinkPreview preview, boolean worthRetrying) {
+
+        static Attempt success(LinkPreview preview) {
+            return new Attempt(preview, false);
+        }
+
+        /** 차단이나 품질 미달 — UA를 바꾸면 결과가 달라질 수 있다. */
+        static Attempt retry() {
+            return new Attempt(null, true);
+        }
+
+        /** UA와 무관한 실패 — 재시도해도 같거나 대기 시간만 늘어난다. */
+        static Attempt giveUp() {
+            return new Attempt(null, false);
+        }
+    }
+}

--- a/src/main/java/com/toit/items/shared/linkpreview/LinkPreviewExtractor.java
+++ b/src/main/java/com/toit/items/shared/linkpreview/LinkPreviewExtractor.java
@@ -1,19 +1,27 @@
 package com.toit.items.shared.linkpreview;
 
 
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.net.URI;
-import java.time.Duration;
+import java.util.List;
 
+/**
+ * 링크 프리뷰 추출 진입점.
+ *
+ * <p>URL을 정규화한 뒤 {@link LinkPreviewStrategy} 구현체들을 우선순위대로 시도한다.
+ * 앞선 전략이 실패하면 다음 전략으로 넘어가고, 최종적으로 {@link JsoupLinkPreviewStrategy}가
+ * 폴백으로 동작한다. 모두 실패해도 예외를 던지지 않고 빈 프리뷰를 돌려주므로
+ * 링크 저장 자체는 항상 성공한다.
+ */
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class LinkPreviewExtractor {
 
-    // 운영에서 적당한 값으로 조절 (너무 길면 요청 스레드 묶임)
-    private static final int TIMEOUT_MS = (int) Duration.ofSeconds(5).toMillis();
+    /** Spring이 {@code @Order} 순으로 정렬해 주입한다. */
+    private final List<LinkPreviewStrategy> strategies;
 
     public LinkPreview extract(String rawUrl) {
         if (rawUrl == null || rawUrl.isBlank()) {
@@ -22,70 +30,19 @@ public class LinkPreviewExtractor {
 
         String normalizedUrl = normalizeUrl(rawUrl);
 
-        try {
-            Document doc = Jsoup.connect(normalizedUrl)
-                    .userAgent("Mozilla/5.0 (compatible; toITLinkBot/1.0)")
-                    .referrer("https://www.google.com")
-                    .timeout(TIMEOUT_MS)
-                    .followRedirects(true)
-                    .get();
-
-            // 최종 URL(리다이렉트 반영)
-            String resolvedUrl = doc.location();
-
-            String title = firstNonBlank(
-                    meta(doc, "property", "og:title"),
-                    meta(doc, "name", "twitter:title"),
-                    doc.title()
-            );
-
-            String description = firstNonBlank(
-                    meta(doc, "property", "og:description"),
-                    meta(doc, "name", "twitter:description"),
-                    meta(doc, "name", "description")
-            );
-
-            String thumbnail = firstNonBlank(
-                    meta(doc, "property", "og:image"),
-                    meta(doc, "name", "twitter:image"),
-                    meta(doc, "property", "twitter:image")
-            );
-
-            // og:image가 상대경로인 경우 absUrl로 보정
-            if (thumbnail != null && !thumbnail.isBlank()) {
-                // meta로 가져온 thumbnail은 content 문자열이라 absUrl이 안 먹음 → 직접 보정
-                thumbnail = absolutize(resolvedUrl, thumbnail);
-            } else {
-                // fallback: favicon
-                Element icon = doc.selectFirst("link[rel~=(?i)^(shortcut )?icon$]");
-                if (icon != null) {
-                    String faviconHref = icon.hasAttr("href") ? icon.attr("href") : "";
-                    String abs = icon.absUrl("href");
-                    thumbnail = (abs != null && !abs.isBlank())
-                            ? abs
-                            : absolutize(resolvedUrl, faviconHref);
-                }
+        for (LinkPreviewStrategy strategy : strategies) {
+            if (!strategy.supports(normalizedUrl)) {
+                continue;
             }
-            return new LinkPreview(resolvedUrl, title, sanitize(description), sanitize(thumbnail));
-
-        } catch (Exception e) {
-            // 운영에서는 logger로 남기고, 서비스는 fallback
-            return empty(normalizedUrl);
+            LinkPreview preview = strategy.extract(normalizedUrl);
+            if (preview != null) {
+                return preview;
+            }
+            // 실패하면 다음 전략으로 폴백한다
         }
-    }
 
-    private static String meta(Document doc, String attrKey, String attrValue) {
-        Element el = doc.selectFirst("meta[" + attrKey + "=" + attrValue + "]");
-        if (el == null) return null;
-        String content = el.attr("content");
-        return (content == null || content.isBlank()) ? null : content.trim();
-    }
-
-    private static String firstNonBlank(String... values) {
-        for (String v : values) {
-            if (v != null && !v.isBlank()) return v.trim();
-        }
-        return null;
+        log.warn("링크 프리뷰 없음(모든 전략 실패) url={}", normalizedUrl);
+        return empty(normalizedUrl);
     }
 
     private static LinkPreview empty(String url) {
@@ -99,27 +56,5 @@ public class LinkPreviewExtractor {
             u = "https://" + u;
         }
         return u;
-    }
-
-    private static String absolutize(String baseUrl, String maybeRelative) {
-        if (maybeRelative == null || maybeRelative.isBlank()) return null;
-        String v = maybeRelative.trim();
-        // 이미 절대경로면 그대로
-        if (v.startsWith("http://") || v.startsWith("https://")) return v;
-
-        try {
-            URI base = URI.create(baseUrl);
-            return base.resolve(v).toString();
-        } catch (Exception e) {
-            return v; // 최후의 fallback
-        }
-    }
-
-    private static String sanitize(String s) {
-        if (s == null) return null;
-        // 길이 제한(DB 컬럼 길이에 맞춰 조절)
-        s = s.strip();
-        if (s.isBlank()) return null;
-        return s.length() > 500 ? s.substring(0, 500) : s;
     }
 }

--- a/src/main/java/com/toit/items/shared/linkpreview/LinkPreviewQuality.java
+++ b/src/main/java/com/toit/items/shared/linkpreview/LinkPreviewQuality.java
@@ -1,0 +1,100 @@
+package com.toit.items.shared.linkpreview;
+
+import java.util.Set;
+
+/**
+ * 추출한 프리뷰가 실제로 쓸만한지 판정한다.
+ *
+ * <p>링크 프리뷰의 실패는 예외로 드러나지 않는다. 로그인 벽이나 봇 판정에 걸린 페이지도
+ * HTTP 200으로 내려오기 때문에, 폴백 로직이 끝까지 내려가 사이트 전체를 설명하는 값
+ * (예: {@code "Instagram"}, {@code "- YouTube"})을 제목으로 잡아 버린다.
+ * 그런 값은 저장하는 것보다 비워 두는 편이 낫다. 사용자가 직접 제목을 수정할 수 있기 때문이다.
+ *
+ * <p>주의: <b>og 태그가 없다는 것 자체는 실패가 아니다.</b> velog처럼 og 태그 없이
+ * {@code <title>}과 {@code meta[name=description]}만 제공하는 정상 사이트가 많다.
+ * 그래서 폴백 단계를 보지 않고 <b>결과값이 쓰레기인지만</b> 판정한다.
+ */
+public final class LinkPreviewQuality {
+
+    /** 판정 결과. OK가 아니면 실패이며, 값 자체가 로그에 남길 사유가 된다. */
+    public enum Verdict {
+        OK,
+        /** 제목을 아무것도 찾지 못했다. */
+        BLANK_TITLE,
+        /** 리다이렉트를 따라간 결과가 로그인·동의 페이지였다. */
+        AUTH_WALL,
+        /** 제목이 서비스명이나 차단 안내문뿐이었다. */
+        JUNK_TITLE;
+
+        public boolean usable() {
+            return this == OK;
+        }
+    }
+
+    /**
+     * 최종 URL에 이 조각이 들어 있으면 원래 보려던 페이지를 보지 못한 것으로 본다.
+     * 오탐이 거의 없어 가장 신뢰도가 높은 신호다.
+     */
+    private static final Set<String> AUTH_WALL_MARKERS = Set.of(
+            "/accounts/login",   // 인스타그램
+            "/authwall",         // 링크드인
+            "/login",
+            "/signin",
+            "/sign_in",
+            "/oauth/authorize",
+            "consent."           // 구글 계열 동의 페이지
+    );
+
+    /**
+     * 제목이 이 값과 <b>정확히 일치</b>할 때만 걸러낸다.
+     * {@code contains}로 비교하면 "Instagram 마케팅 완전정복" 같은 정상 제목까지 막힌다.
+     *
+     * <p>미리 완성할 수 없는 목록이다. 품질 미달 로그를 보고 계속 늘려야 한다.
+     */
+    private static final Set<String> JUNK_TITLES = Set.of(
+            // 서비스명만 돌아온 경우
+            "instagram", "linkedin", "facebook", "threads", "youtube", "- youtube",
+            "x", "twitter", "tiktok",
+            // 로그인 요구
+            "log in", "login", "log in or sign up", "sign in", "sign up",
+            "로그인", "로그인 - ", "로그인하세요",
+            // 봇 차단·챌린지 페이지
+            "just a moment...", "attention required!", "access denied", "forbidden",
+            "are you a robot?", "verify you are human", "security check",
+            "잠시만 기다려주세요", "접근이 거부되었습니다",
+            // 빈 껍데기
+            "error", "not found", "404 not found", "페이지를 찾을 수 없습니다"
+    );
+
+    private LinkPreviewQuality() {
+    }
+
+    /**
+     * @param title       추출한 제목
+     * @param resolvedUrl 리다이렉트를 모두 따라간 최종 URL
+     */
+    public static Verdict judge(String title, String resolvedUrl) {
+        if (title == null || title.isBlank()) {
+            return Verdict.BLANK_TITLE;
+        }
+        if (isAuthWall(resolvedUrl)) {
+            return Verdict.AUTH_WALL;
+        }
+        if (isJunkTitle(title)) {
+            return Verdict.JUNK_TITLE;
+        }
+        return Verdict.OK;
+    }
+
+    private static boolean isAuthWall(String resolvedUrl) {
+        if (resolvedUrl == null || resolvedUrl.isBlank()) {
+            return false;
+        }
+        String lower = resolvedUrl.toLowerCase();
+        return AUTH_WALL_MARKERS.stream().anyMatch(lower::contains);
+    }
+
+    private static boolean isJunkTitle(String title) {
+        return JUNK_TITLES.contains(title.strip().toLowerCase());
+    }
+}

--- a/src/main/java/com/toit/items/shared/linkpreview/LinkPreviewStrategy.java
+++ b/src/main/java/com/toit/items/shared/linkpreview/LinkPreviewStrategy.java
@@ -1,0 +1,79 @@
+package com.toit.items.shared.linkpreview;
+
+import java.net.URI;
+
+/**
+ * 링크 프리뷰 추출 전략.
+ *
+ * <p>사이트마다 프리뷰를 얻는 방법이 다르다. 대부분은 HTML의 og 태그를 읽으면 되지만,
+ * 유튜브처럼 데이터센터 IP에서 온 요청에는 메타데이터를 뺀 HTML을 내려주는 곳이 있어
+ * 해당 사이트가 공식 제공하는 API를 따로 호출해야 한다.
+ *
+ * <p>전략은 {@link org.springframework.core.annotation.Order} 순으로 시도되며,
+ * 마지막에 항상 {@link JsoupLinkPreviewStrategy}가 폴백으로 동작한다.
+ * 새 사이트 대응이 필요하면 이 인터페이스 구현체를 추가하기만 하면 된다.
+ */
+public interface LinkPreviewStrategy {
+
+    /** 이 전략이 처리할 수 있는 URL인지 판단한다. */
+    boolean supports(String url);
+
+    /**
+     * 프리뷰를 추출한다.
+     *
+     * @return 추출 실패 시 {@code null}. 호출자는 다음 전략으로 폴백한다.
+     */
+    LinkPreview extract(String url);
+
+    /** URL에서 호스트를 꺼낸다. 파싱할 수 없는 URL이면 {@code null}. */
+    static String hostOf(String url) {
+        try {
+            String host = URI.create(url).getHost();
+            return (host == null) ? null : host.toLowerCase();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** {@code Links.linksName} 컬럼 길이 */
+    int TITLE_MAX = 255;
+
+    /** {@code ItemsBase.textContent} 컬럼 길이 */
+    int DESCRIPTION_MAX = 1000;
+
+    /** {@code Links.linksThumbnail} 컬럼 길이 */
+    int URL_MAX = 2000;
+
+    /** 제목을 컬럼 길이에 맞춘다. 넘치면 잘라도 의미가 보존된다. */
+    static String sanitizeTitle(String title) {
+        return truncate(title, TITLE_MAX);
+    }
+
+    /** 설명을 컬럼 길이에 맞춘다. 넘치면 잘라도 의미가 보존된다. */
+    static String sanitizeDescription(String description) {
+        return truncate(description, DESCRIPTION_MAX);
+    }
+
+    /**
+     * URL은 <b>절대 중간에서 자르지 않는다.</b>
+     *
+     * <p>인스타그램 CDN 같은 서명된 URL은 뒤쪽에 서명({@code oh})과 만료 시각({@code oe})이
+     * 붙어 500자를 넘는다(실측 557자). 잘라내면 이미지가 아예 안 뜨므로,
+     * <b>잘린 URL을 저장하는 것보다 비워 두는 편이 낫다.</b>
+     *
+     * @return 컬럼 길이를 넘으면 {@code null}
+     */
+    static String sanitizeUrl(String url) {
+        if (url == null) return null;
+        String trimmed = url.strip();
+        if (trimmed.isBlank()) return null;
+        return (trimmed.length() > URL_MAX) ? null : trimmed;
+    }
+
+    private static String truncate(String s, int max) {
+        if (s == null) return null;
+        String trimmed = s.strip();
+        if (trimmed.isBlank()) return null;
+        return (trimmed.length() > max) ? trimmed.substring(0, max) : trimmed;
+    }
+}

--- a/src/main/java/com/toit/items/shared/linkpreview/OEmbedClient.java
+++ b/src/main/java/com/toit/items/shared/linkpreview/OEmbedClient.java
@@ -1,0 +1,109 @@
+package com.toit.items.shared.linkpreview;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+/**
+ * oEmbed 엔드포인트를 호출해 프리뷰 값을 얻는다.
+ *
+ * <p>oEmbed는 사이트가 링크 프리뷰용으로 공개해 둔 공식 창구다. HTML을 긁는 것과 달리
+ * 봇 판정 대상이 아니어서, 데이터센터 IP에서 호출해도 정상 응답을 준다.
+ *
+ * <p>엔드포인트 주소는 HTML {@code <head>}의 자동 발견 링크에서 얻는다.
+ * 사이트별로 코드를 넣지 않아도 oEmbed를 지원하는 사이트가 모두 커버된다.
+ * <pre>{@code
+ * <link rel="alternate" type="application/json+oembed" href="https://.../oembed?url=...">
+ * }</pre>
+ *
+ * @see <a href="https://oembed.com/">oEmbed 스펙 - Discovery</a>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OEmbedClient {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(3);
+
+    private final ObjectMapper objectMapper;
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(TIMEOUT)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+
+    /**
+     * @param endpointUrl 자동 발견 링크에서 얻은 oEmbed 엔드포인트(쿼리 포함)
+     * @param pageUrl     프리뷰 대상 페이지의 최종 URL. 응답의 {@code resolvedUrl}로 쓴다.
+     * @return 값을 얻지 못하면 {@code null}. 호출자는 다음 수단으로 폴백한다.
+     */
+    public LinkPreview fetch(String endpointUrl, String pageUrl) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(endpointUrl))
+                    .timeout(TIMEOUT)
+                    .header("Accept", "application/json")
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response =
+                    httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+
+            if (response.statusCode() != 200) {
+                log.info("oEmbed 응답 없음 endpoint={} status={}", endpointUrl, response.statusCode());
+                return null;
+            }
+
+            JsonNode json = objectMapper.readTree(response.body());
+            String title = text(json, "title");
+            String thumbnail = text(json, "thumbnail_url");
+            // oEmbed 규격에는 설명 필드가 없다. 프리뷰 카드에 함께 노출되는 제공자·작성자를 대신 쓴다.
+            String description = firstNonBlank(text(json, "author_name"), text(json, "provider_name"));
+
+            if (title == null && thumbnail == null) {
+                log.info("oEmbed 내용 없음 endpoint={}", endpointUrl);
+                return null;
+            }
+
+            log.info("oEmbed 자동 발견 성공 pageUrl={} endpoint={} title={}", pageUrl, endpointUrl, title);
+            return new LinkPreview(
+                    pageUrl,
+                    LinkPreviewStrategy.sanitizeTitle(title),
+                    LinkPreviewStrategy.sanitizeDescription(description),
+                    LinkPreviewStrategy.sanitizeUrl(thumbnail));
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("oEmbed 중단 endpoint={}", endpointUrl);
+            return null;
+        } catch (Exception e) {
+            log.warn("oEmbed 실패 endpoint={} cause={}: {}",
+                    endpointUrl, e.getClass().getSimpleName(), e.getMessage());
+            return null;
+        }
+    }
+
+    private static String text(JsonNode json, String field) {
+        JsonNode node = json.get(field);
+        if (node == null || !node.isTextual()) {
+            return null;
+        }
+        String value = node.asText().trim();
+        return value.isEmpty() ? null : value;
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String v : values) {
+            if (v != null && !v.isBlank()) return v;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/toit/items/shared/linkpreview/WalledSiteStrategy.java
+++ b/src/main/java/com/toit/items/shared/linkpreview/WalledSiteStrategy.java
@@ -1,0 +1,47 @@
+package com.toit.items.shared.linkpreview;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * 비로그인 접근이 막혀 있어 프리뷰를 얻을 방법이 없는 사이트를 즉시 빈 프리뷰로 끝낸다.
+ *
+ * <p>이 사이트들은 HTML을 긁어도 로그인 벽({@code /authwall})이나 서비스명만 돌아온다.
+ * 그대로 저장하면 제목이 {@code "LinkedIn"}, 썸네일이 링크드인 로고가 되어
+ * <b>모든 링크가 똑같이 보인다.</b> 잘못된 값을 저장하는 것보다 비워 두는 편이 낫다.
+ * 사용자는 {@code PATCH /links/update}로 직접 제목을 넣을 수 있다.
+ *
+ * <p>{@link JsoupLinkPreviewStrategy}가 어차피 {@link LinkPreviewQuality}로 걸러내지만,
+ * 결과가 뻔한 요청을 미리 끊어 불필요한 외부 호출과 대기 시간을 없앤다.
+ *
+ * <p><b>인스타그램은 여기 넣지 않았다.</b> 크롤러 User-Agent로 요청하면 og 태그를 주기
+ * 때문이다({@link JsoupLinkPreviewStrategy} 참고). 그 경로가 운영에서 통하지 않는다고
+ * 확인되면 그때 이 목록으로 옮기면 된다.
+ */
+@Slf4j
+@Order(150)
+@Component
+public class WalledSiteStrategy implements LinkPreviewStrategy {
+
+    private static final Set<String> WALLED_HOSTS = Set.of(
+            "linkedin.com", "www.linkedin.com", "kr.linkedin.com",
+            "x.com", "www.x.com",
+            "twitter.com", "www.twitter.com", "mobile.twitter.com"
+    );
+
+    @Override
+    public boolean supports(String url) {
+        String host = LinkPreviewStrategy.hostOf(url);
+        return host != null && WALLED_HOSTS.contains(host);
+    }
+
+    @Override
+    public LinkPreview extract(String url) {
+        log.info("링크 프리뷰 생략(비로그인 접근 불가 사이트) url={}", url);
+        // null이 아니라 빈 프리뷰를 돌려 Jsoup 폴백까지 가지 않게 한다
+        return new LinkPreview(url, null, null, null);
+    }
+}

--- a/src/main/java/com/toit/items/shared/linkpreview/YouTubeOEmbedStrategy.java
+++ b/src/main/java/com/toit/items/shared/linkpreview/YouTubeOEmbedStrategy.java
@@ -1,0 +1,125 @@
+package com.toit.items.shared.linkpreview;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Set;
+
+/**
+ * 유튜브 링크 프리뷰 - 공식 oEmbed API 사용.
+ *
+ * <p>유튜브는 데이터센터(AWS 등) IP에서 크롤링하면 200을 주면서도 제목/썸네일이 빠진
+ * 껍데기 HTML을 내려준다. User-Agent를 브라우저로 위장해도 소용없는데, IP 대역으로
+ * 판별하기 때문이다. 반면 oEmbed는 링크 프리뷰용으로 공개된 공식 창구라
+ * 서버에서 호출해도 정상적으로 메타데이터를 준다.
+ *
+ * <p>watch / youtu.be / shorts / m.youtube 등 URL 형태를 엔드포인트가 모두 처리하므로
+ * 영상 ID를 직접 파싱하지 않고 URL을 그대로 넘긴다.
+ */
+@Slf4j
+@Order(100)
+@Component
+@RequiredArgsConstructor
+public class YouTubeOEmbedStrategy implements LinkPreviewStrategy {
+
+    private static final Set<String> YOUTUBE_HOSTS = Set.of(
+            "youtube.com", "www.youtube.com", "m.youtube.com",
+            "music.youtube.com", "youtu.be", "www.youtu.be"
+    );
+
+    private static final String OEMBED_ENDPOINT = "https://www.youtube.com/oembed";
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    private final ObjectMapper objectMapper;
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(TIMEOUT)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+
+    @Override
+    public boolean supports(String url) {
+        String host = LinkPreviewStrategy.hostOf(url);
+        return host != null && YOUTUBE_HOSTS.contains(host);
+    }
+
+    @Override
+    public LinkPreview extract(String url) {
+        String requestUrl = OEMBED_ENDPOINT
+                + "?url=" + URLEncoder.encode(url, StandardCharsets.UTF_8)
+                + "&format=json";
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(requestUrl))
+                    .timeout(TIMEOUT)
+                    .header("Accept", "application/json")
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response =
+                    httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+
+            if (response.statusCode() != 200) {
+                // 비공개/삭제된 영상이거나 영상 URL이 아니면 400, 없는 영상이면 404
+                log.info("유튜브 oEmbed 응답 없음 url={} status={}", url, response.statusCode());
+                return emptyPreview(url);
+            }
+
+            JsonNode json = objectMapper.readTree(response.body());
+            String title = text(json, "title");
+            String thumbnail = text(json, "thumbnail_url");
+            // oEmbed에는 영상 설명이 없다. 프리뷰 카드에 보통 함께 노출되는 채널명을 대신 쓴다.
+            String author = text(json, "author_name");
+
+            if (title == null && thumbnail == null) {
+                log.info("유튜브 oEmbed 내용 없음 url={}", url);
+                return emptyPreview(url);
+            }
+
+            log.info("유튜브 oEmbed 성공 url={} title={}", url, title);
+            return new LinkPreview(
+                    url,
+                    LinkPreviewStrategy.sanitizeTitle(title),
+                    LinkPreviewStrategy.sanitizeDescription(author),
+                    LinkPreviewStrategy.sanitizeUrl(thumbnail));
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("유튜브 oEmbed 중단 url={}", url);
+            return null;
+        } catch (Exception e) {
+            log.warn("유튜브 oEmbed 실패 url={} cause={}: {}",
+                    url, e.getClass().getSimpleName(), e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 유튜브 URL인데 oEmbed로 값을 못 얻은 경우 Jsoup 폴백으로 넘기지 않고 빈 프리뷰로 끝낸다.
+     * 유튜브 HTML은 크롤링해 봐야 제목이 {@code "- YouTube"}, 설명은 유튜브 홈 소개문,
+     * 썸네일은 파비콘으로 잡혀 오히려 잘못된 값이 저장되기 때문이다.
+     */
+    private static LinkPreview emptyPreview(String url) {
+        return new LinkPreview(url, null, null, null);
+    }
+
+    private static String text(JsonNode json, String field) {
+        JsonNode node = json.get(field);
+        if (node == null || !node.isTextual()) {
+            return null;
+        }
+        String value = node.asText().trim();
+        return value.isEmpty() ? null : value;
+    }
+}

--- a/src/test/java/com/toit/items/linkpreview/LinkPreviewQualityTest.java
+++ b/src/test/java/com/toit/items/linkpreview/LinkPreviewQualityTest.java
@@ -1,0 +1,93 @@
+package com.toit.items.linkpreview;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.toit.items.shared.linkpreview.LinkPreviewQuality;
+import com.toit.items.shared.linkpreview.LinkPreviewQuality.Verdict;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LinkPreviewQualityTest {
+
+    private static final String NORMAL_URL = "https://velog.io/@velopert/react-hooks";
+
+    @Test
+    @DisplayName("정상적인 제목은 통과한다")
+    void judge_shouldPass_whenTitleIsMeaningful() {
+        Verdict verdict = LinkPreviewQuality.judge("리액트의 Hooks 완벽 정복하기", NORMAL_URL);
+
+        assertEquals(Verdict.OK, verdict);
+        assertTrue(verdict.usable());
+    }
+
+    @Test
+    @DisplayName("제목이 없으면 BLANK_TITLE로 판정한다")
+    void judge_shouldReturnBlankTitle_whenTitleIsMissing() {
+        assertEquals(Verdict.BLANK_TITLE, LinkPreviewQuality.judge(null, NORMAL_URL));
+        assertEquals(Verdict.BLANK_TITLE, LinkPreviewQuality.judge("   ", NORMAL_URL));
+    }
+
+    @Test
+    @DisplayName("리다이렉트 결과가 로그인 페이지면 AUTH_WALL로 판정한다")
+    void judge_shouldReturnAuthWall_whenRedirectedToLoginPage() {
+        Verdict instagram = LinkPreviewQuality.judge(
+                "로그인 • Instagram",
+                "https://www.instagram.com/accounts/login/?next=%2Fp%2FABC123%2F");
+        Verdict linkedIn = LinkPreviewQuality.judge(
+                "회원가입 | LinkedIn",
+                "https://www.linkedin.com/authwall?trk=bf&originalReferer=");
+
+        assertEquals(Verdict.AUTH_WALL, instagram);
+        assertEquals(Verdict.AUTH_WALL, linkedIn);
+    }
+
+    @Test
+    @DisplayName("제목이 서비스명뿐이면 JUNK_TITLE로 판정한다")
+    void judge_shouldReturnJunkTitle_whenTitleIsOnlyServiceName() {
+        // 인스타그램이 봇 판정 시 내려주는 껍데기 페이지의 <title>
+        assertEquals(Verdict.JUNK_TITLE, LinkPreviewQuality.judge("Instagram", NORMAL_URL));
+        // 유튜브 HTML을 데이터센터 IP에서 긁었을 때 잡히는 값
+        assertEquals(Verdict.JUNK_TITLE, LinkPreviewQuality.judge("- YouTube", NORMAL_URL));
+    }
+
+    @Test
+    @DisplayName("Cloudflare 챌린지 페이지의 제목을 걸러낸다")
+    void judge_shouldReturnJunkTitle_whenTitleIsBotChallengePage() {
+        assertEquals(Verdict.JUNK_TITLE, LinkPreviewQuality.judge("Just a moment...", NORMAL_URL));
+        assertEquals(Verdict.JUNK_TITLE, LinkPreviewQuality.judge("Attention Required!", NORMAL_URL));
+    }
+
+    @Test
+    @DisplayName("대소문자와 앞뒤 공백에 관계없이 걸러낸다")
+    void judge_shouldReturnJunkTitle_regardlessOfCaseAndWhitespace() {
+        assertEquals(Verdict.JUNK_TITLE, LinkPreviewQuality.judge("  INSTAGRAM  ", NORMAL_URL));
+        assertEquals(Verdict.JUNK_TITLE, LinkPreviewQuality.judge("Just A Moment...", NORMAL_URL));
+    }
+
+    @Test
+    @DisplayName("서비스명이 포함되기만 한 정상 제목은 통과한다")
+    void judge_shouldPass_whenTitleMerelyContainsServiceName() {
+        // contains로 비교하면 이런 정상 제목까지 막힌다. 정확히 일치할 때만 걸러야 한다.
+        assertTrue(LinkPreviewQuality.judge("Instagram 마케팅 완전정복", NORMAL_URL).usable());
+        assertTrue(LinkPreviewQuality.judge("YouTube 알고리즘 분석", NORMAL_URL).usable());
+    }
+
+    @Test
+    @DisplayName("og 태그 없이 <title>로 폴백한 것만으로는 실패로 보지 않는다")
+    void judge_shouldPass_whenSiteHasNoOgTagsButValidTitle() {
+        // velog는 og 태그가 없고 <title>과 meta[name=description]만 제공하는 정상 사이트다.
+        // 폴백 단계를 실패 근거로 쓰면 이런 사이트가 함께 막힌다.
+        Verdict verdict = LinkPreviewQuality.judge("리액트의 Hooks 완벽 정복하기", NORMAL_URL);
+
+        assertTrue(verdict.usable());
+    }
+
+    @Test
+    @DisplayName("최종 URL이 없어도 제목만으로 판정한다")
+    void judge_shouldNotFail_whenResolvedUrlIsMissing() {
+        assertTrue(LinkPreviewQuality.judge("정상 제목", null).usable());
+        assertFalse(LinkPreviewQuality.judge("Instagram", null).usable());
+    }
+}


### PR DESCRIPTION
## 개요

링크 프리뷰 추출을 **전략 패턴으로 분리**하고, **결과값 품질 검증**을 도입합니다.

기존에는 `LinkPreviewExtractor` 하나에 Jsoup 로직이 전부 들어 있어 사이트별 대응을 추가할 자리가 없었습니다. 그리고 더 큰 문제로, **로컬(mac)에서는 정상 추출되던 메타데이터가 AWS에 배포하면 전혀 다른 값으로 저장**되고 있었습니다.

같은 유튜브 링크(`https://youtu.be/yAB9BgFdFso`)를 양쪽에서 저장한 결과입니다.

| | 로컬 | 운영(AWS) |
| --- | --- | --- |
| `title` | 뽕을 뽑아야만 하는 사나이 | **`- YouTube`** |
| `description` | #겟앰프드 #나는벌레 ... | **유튜브 홈 소개문** |
| `thumbnail` | `.../maxresdefault.jpg` | **유튜브 파비콘** |

**예외도 나지 않고 HTTP 상태코드도 `200`이라 로그에 아무것도 남지 않았습니다.** 원인 추적부터 필요했습니다.

## 원인

### 응답 본문 자체가 달랐습니다

서버 셸에서 `curl`로 직접 비교했습니다. NGINX·Spring·Jsoup을 모두 우회했는데도 결과가 같았으므로 **애플리케이션 스택은 원인이 아닙니다.**

| | 로컬 | 운영(AWS) |
| --- | --- | --- |
| HTTP 상태 | `200` | `200` |
| 응답 크기 | 1,185,169 bytes | 1,134,095 bytes |
| 프론트엔드 빌드 | `...20260730.06_p0` | **동일** |
| `og:` 태그 블록 | 있음 | **없음** |

차단도, 다른 페이지도, 다른 언어도 아닙니다(`lang="ko-KR"`, `"countryCode":"KR"` 양쪽 동일). **정상 페이지에서 `og:` 메타태그 블록만 빠졌습니다.**

### 출발지 IP가 EC2로 식별됩니다

유튜브 응답 안에 우리 서버의 요청 IP가 그대로 찍혀 있었고(`initplayback` URL의 `ip` 파라미터), 그 값을 [AWS가 공개하는 IP 대역 목록](https://docs.aws.amazon.com/vpc/latest/userguide/aws-ip-ranges.html)에서 조회한 결과입니다.

```
조회 대상: 2406:da12:fd:4800:28f0:a7a5:5d5:1b9e

일치: 2406:da12::/36   region=ap-northeast-2   service=AMAZON
일치: 2406:da12::/36   region=ap-northeast-2   service=EC2
```

AWS 문서는 이 목록의 용도를 **"AWS발 트래픽을 식별하고 허용하거나 거부"** 하는 것으로 명시합니다. 즉 상대 서버가 우리를 데이터센터로 판정할 수 있는 자료가 공개되어 있습니다.

**차단이 아니라 프리뷰용 태그만 선별 제거하는 방식**이라 상태코드로는 감지할 수 없었습니다. 완전 차단이었다면 `.get()`이 예외를 던져 코드가 알아챘을 것입니다.

> 유튜브 내부 판정 규칙은 비공개입니다. 확인한 것은 "판정에 쓸 수 있는 공개 자료가 있고 우리 IP가 거기서 EC2로 식별된다"는 것까지이며, 유튜브가 실제로 이 파일을 쓴다는 증거는 아닙니다.

## 변경 사항

### 1. 전략 패턴으로 분리

사이트마다 방법이 달라서 **구현체 추가만으로 대응되는 구조**로 바꿨습니다.

```
YouTubeOEmbedStrategy     @Order(100)      유튜브 → 공식 oEmbed
WalledSiteStrategy        @Order(150)      링크드인·X → 빈 프리뷰
JsoupLinkPreviewStrategy  @Order(LOWEST)   나머지 → HTML + UA 폴백 + oEmbed 발견
```

`LinkPreviewExtractor`는 전략을 순회하는 진입점으로 축소했습니다(91줄 → 26줄).

- 전략이 `null`을 반환하면 다음 전략으로 폴백
- 모두 실패해도 **예외를 던지지 않고 빈 프리뷰를 반환** — 프리뷰는 부가 정보이고 사용자가 원한 건 링크 저장이므로, 프리뷰 실패가 저장 실패가 되지 않게 유지했습니다

### 2. 유튜브 — 공식 oEmbed 사용

유튜브는 **IP로 판별하기 때문에 User-Agent를 바꿔도 소용이 없습니다.** 대신 oEmbed는 링크 프리뷰용으로 공개된 창구라 봇 판정 대상이 아니고, **운영 서버에서 호출해도 로컬과 동일한 값이 옵니다.**

- `watch` / `youtu.be` / `shorts` / `m.youtube`를 엔드포인트가 모두 처리하므로 영상 ID를 파싱하지 않고 URL을 그대로 전달
- oEmbed에는 설명 필드가 없어 프리뷰 카드에 함께 노출되는 채널명(`author_name`)으로 대체
- 썸네일이 `hqdefault`(480×360)로 og 태그의 `maxresdefault`(1280×720)보다 작습니다. **정보를 조금 포기하고 안정성을 얻는 선택입니다**
- oEmbed 실패 시 HTML 폴백으로 넘기지 않고 빈 프리뷰로 종료 — 유튜브 HTML은 긁어봐야 `- YouTube`가 잡혀 오히려 잘못된 값이 저장되기 때문입니다

### 3. 품질 검증 도입 (`LinkPreviewQuality`)

**이번 PR에서 가장 중요한 부분입니다.** 사이트별 대응은 계속 늘려야 하는 작업이지만, 이건 한 번 넣으면 모르는 사이트에도 적용됩니다.

`200`이어도 쓸만한 값을 받았는지 판정합니다.

| 판정 | 조건 |
| --- | --- |
| `AUTH_WALL` | 최종 URL이 `/accounts/login`, `/authwall` 등으로 바뀐 경우 |
| `JUNK_TITLE` | 제목이 서비스명·차단 안내문과 **정확히 일치**하는 경우 |
| `BLANK_TITLE` | 제목을 아무것도 찾지 못한 경우 |

미달이면 `null`을 반환해 기존 폴백 흐름을 그대로 타고, 최종적으로 빈 값이 저장됩니다. **잘못된 값보다 빈 값이 낫습니다** — 사용자는 `PATCH /links/update`로 직접 채울 수 있습니다.

두 가지를 의도적으로 조심했습니다.

- **og 태그 부재는 실패로 보지 않습니다.** velog처럼 og 태그 없이 `<title>`과 `meta[name=description]`만 제공하는 정상 사이트가 많습니다. 폴백 단계를 실패 근거로 쓰면 이런 사이트가 함께 막힙니다
- **제목은 정확히 일치할 때만 걸러냅니다.** `contains`로 비교하면 `"Instagram 마케팅 완전정복"` 같은 정상 제목까지 막힙니다

테스트 9개를 추가했습니다.

### 4. User-Agent 2단 폴백

`og:` 태그는 애초에 링크 프리뷰 크롤러를 위해 만들어진 규격이라, **알려진 크롤러에게만 og 태그를 내려주는 사이트가 있습니다.** 인스타그램 릴스에 UA만 바꿔 요청한 실측 결과입니다.

| User-Agent | 응답 크기 | og 태그 |
| --- | --- | --- |
| `facebookexternalhit/1.1` | 669,714 bytes | **6개** |
| `Twitterbot/1.0` | 638,654 bytes | **6개** |
| `Mozilla/5.0 ... Chrome/126` | 605,700 bytes | **0개** |

**브라우저 UA를 쓰는 것이 오히려 역효과였습니다.** 반대로 Cloudflare·Akamai 같은 WAF 뒤에 있는 사이트는 봇 UA를 차단하므로, 어느 한쪽으로 고정하면 반대쪽을 놓칩니다. 그래서 둘 다 시도합니다.

```
1차: facebookexternalhit/1.1   →  인스타 계열
2차: 브라우저 UA                →  WAF 사이트
3차: 빈 프리뷰
```

대다수 사이트는 UA와 무관하게 og 태그를 주므로 **1차에서 끝나고 요청은 한 번만 나갑니다.**

응답 시간이 늘어나지 않도록 재시도 조건을 제한했습니다.

- `4xx/5xx`·품질 미달만 재시도 (WAF가 봇 UA를 막은 경우일 수 있음)
- 타임아웃·비HTML은 즉시 포기 (UA를 바꿔도 결과가 같고 대기 시간만 2배가 됨)
- 타임아웃 5초 → 4초 (2회 시도 시 최악 8초)

### 5. oEmbed 자동 발견 (`OEmbedClient`)

og 태그가 부족하면 `<head>`의 자동 발견 링크를 찾아 호출합니다.

```html
<link rel="alternate" type="application/json+oembed" href="https://.../oembed?url=...">
```

**사이트별 코드를 넣지 않아도 oEmbed 지원 사이트가 커버됩니다.** ([oEmbed 스펙](https://oembed.com/))

### 6. 로그 정비

문제를 인지할 수 없었던 것 자체가 결함이었습니다.

- **품질 미달 시 `warn`** — `url` / `finalUrl` / `title` / 사유 / `ua`
- **성공 로그 `debug` → `info`** — 루트 레벨이 `INFO`라 운영에서 보이지 않았습니다. 성공도 보여야 미달 비율을 판단할 수 있습니다
- 중간 시도 실패는 `info`, 마지막 시도만 `warn` (재시도할 것이므로 로그를 시끄럽게 만들지 않음)

블로클리스트를 미리 완성할 방법이 없습니다. **운영에 쌓인 로그로 패턴을 늘려가는 것이 유일하게 지속 가능한 방법**이라 로그가 검증 게이트와 한 쌍입니다.

### 7. 썸네일 URL이 잘려 이미지가 깨지던 문제 수정

`sanitize()`가 제목·설명·썸네일에 **모두 500자 제한**을 적용하고 있었습니다.

```
...&oh=00_AQE6uJWUr9fR63cudLkX5x8yYDLKvroK8AgD0ZH7eqRblg&oe=6A789521
                                                          └─── 여기가 잘렸다
```

인스타그램 CDN 썸네일 URL은 **509자**(서명 `oh`, 만료 `oe` 포함)라 뒤쪽이 잘려 서명 검증에 실패하고, 이미지가 아예 표시되지 않았습니다.

컬럼 길이를 확인하니 문제가 3개였습니다.

| 필드 | DB 컬럼 | 기존 | 수정 후 |
| --- | --- | --- | --- |
| `thumbnail` | 2000 | 500자 절단 → **URL 파손** | **절단 안 함.** 초과 시 `null` |
| `title` | **255** | **검사 없음** → insert 실패 가능 | 255자로 절단 |
| `description` | 1000 | 500자 절단 | 1000자로 절단 |

URL은 잘린 값을 저장하는 것보다 비워 두는 편이 낫기 때문에 초과 시 `null`로 처리합니다. 길이 상수는 `LinkPreviewStrategy`로 옮겨 세 전략이 공유하고, 어느 컬럼에 대응하는지 주석으로 남겼습니다.

## 검증

실제 사이트로 확인했습니다.

| URL | 결과 |
| --- | --- |
| 인스타그램 릴스 | ✅ 제목·설명·CDN 썸네일 정상 |
| velog (og 태그 없는 사이트) | ✅ `리액트의 Hooks 완벽 정복하기` |
| Vimeo | ✅ `The New Vimeo Player (You Know, For Videos)` |
| 링크드인 | ✅ `AUTH_WALL` 감지 → 빈 프리뷰 |

인스타그램 썸네일은 이미지 요청까지 확인했습니다 — `200 image/jpeg 41,083 bytes`.

링크드인은 로그가 이렇게 남습니다.

```
INFO  링크 프리뷰 품질 미달 ... finalUrl=.../uas/login?session_redirect=... 사유=AUTH_WALL ua=facebookexternalhit/1.1
WARN  링크 프리뷰 품질 미달 ... 사유=AUTH_WALL ua=Mozilla/5.0
```

**테스트** — `LinkPreviewQualityTest` 9개 통과. 기존 테스트 중 `PresignedUrlExpiryTest` 1개가 실패하는데, 로컬에 `AWS_REGION` 환경변수가 없어 `${AWS_REGION}`이 치환되지 않고 S3Client 빈 생성이 실패하는 **기존 환경 이슈**입니다. 해당 테스트는 linkpreview를 참조하지 않습니다.

## 배포 후 확인이 필요한 것

**크롤러 UA 측정은 로컬(가정용 IP)에서 수행했습니다.** 데이터센터 IP에서는 판정 점수가 달라 결과가 다를 수 있습니다. 로컬에서 통했다고 운영에서 통하리라 가정하는 것이 이 PR의 출발점이 된 바로 그 실수입니다.

운영 로그에서 아래가 남으면 성공입니다.

```
INFO 링크 프리뷰 성공 url=https://www.instagram.com/... ua=facebookexternalhit/1.1
```

실패한다면 인스타그램을 `WalledSiteStrategy.WALLED_HOSTS`로 옮기면 됩니다.

## 남은 과제

- **인스타그램 CDN URL은 만료됩니다.** `oe` 파라미터를 해석하면 측정 시점 기준 약 4일 후였습니다. 저장된 썸네일이 이후 깨지므로 S3 복사 등 별도 대응이 필요합니다. 이건 서명된 CDN URL을 쓰는 사이트 전체에 해당합니다
- **프리뷰 추출이 동기입니다.** 링크 저장 응답 시간에 직접 붙어 있어 무거운 수단(헤드리스 브라우저 등)을 쓸 수 없습니다. 비동기로 분리하면 추출 수단을 자유롭게 교체할 수 있습니다
- **UA 사칭** — `facebookexternalhit/1.1`은 실제로는 Meta 크롤러가 아닙니다. 규범에 맞는 방식은 연락처를 담은 자체 UA(`toITLinkBot/1.0 (+https://.../bot)`)지만, 화이트리스트 방식인 사이트에서는 알려지지 않은 UA가 우대받지 못해 효과가 없습니다. 또한 Meta가 요청 IP 검증을 추가하면 그날부터 통하지 않습니다. **영구적 해결책이 아니라 지금 통하는 방법**으로 보고 실패 시 조용히 폴백하도록 구성했습니다
- **SSRF 방어가 없습니다.** 사용자가 준 URL을 서버가 그대로 요청하고 `followRedirects(true)`라, `http://169.254.169.254/latest/meta-data/`나 내부 주소를 넣으면 서버가 내부망으로 요청을 보냅니다. 이 PR 범위를 넘어서므로 별도 이슈로 다루는 것이 좋겠습니다
