### PR TITLE
PostgreSQL → MySQL 전환 및 탈퇴 복구 기능 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	// MySQL 전환 검증 기간 동안 롤백용으로 유지 (드라이버/방언 두 줄만 되돌리면 복귀)
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/toit/auth/AuthController.java
+++ b/src/main/java/com/toit/auth/AuthController.java
@@ -56,12 +56,6 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "탈퇴 계정 복구", description = "복구 토큰으로 탈퇴한 계정을 복구하고 로그인 토큰을 발급합니다.")
-    @PostMapping("/restore")
-    public ResponseEntity<AuthService.LoginTokens> restoreAccount(@RequestParam String restoreToken) {
-        return ResponseEntity.ok(authService.restoreAccount(restoreToken));
-    }
-
     @Operation(summary = "CloudFront Signed Cookie 발급 및 재발급", description = "이미지 조회에 필요한 CloudFront Signed Cookie를 발급합니다. 만료 시 동일 API로 재발급합니다.")
     @GetMapping("/cloudfront/cookie")
     public ResponseEntity<Map<String, String>> issueCloudFrontCookie() {

--- a/src/main/java/com/toit/auth/AuthService.java
+++ b/src/main/java/com/toit/auth/AuthService.java
@@ -75,27 +75,6 @@ public class AuthService {
     }
 
     /**
-     * 복구 토큰을 검증하고 계정을 복구한 뒤 로그인 토큰을 발급합니다.
-     */
-    @Transactional
-    public LoginTokens restoreAccount(String restoreToken) {
-        if (!jwtProvider.validateToken(restoreToken) || !jwtProvider.isRestoreToken(restoreToken)) {
-            throw new RuntimeException("유효하지 않은 복구 토큰입니다.");
-        }
-
-        Long usersId = Long.parseLong(jwtProvider.getUserId(restoreToken));
-        Users user = usersRepository.findById(usersId)
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자입니다."));
-
-        if (!user.isDeleted()) {
-            throw new RuntimeException("탈퇴한 계정이 아닙니다.");
-        }
-
-        user.restore();
-        return issueLoginTokens(user);
-    }
-
-    /**
      * 현재 로그인한 사용자의 정보와 온보딩(닉네임 설정) 필요 여부를 반환합니다.
      * 액세스 토큰이 유효하면 호출되며, needsNickname 으로 신규 사용자 여부를 판별합니다.
      */

--- a/src/main/java/com/toit/auth/handler/AuthSuccessHandler.java
+++ b/src/main/java/com/toit/auth/handler/AuthSuccessHandler.java
@@ -3,7 +3,6 @@ package com.toit.auth.handler;
 
 
 import com.toit.auth.AuthService;
-import com.toit.auth.jwt.JwtProvider;
 import com.toit.auth.login.SocialLoginResult;
 import com.toit.user.Users;
 import com.toit.user.UsersRepository;
@@ -27,7 +26,6 @@ public class AuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final AuthService authService;
     private final UsersRepository usersRepository;
-    private final JwtProvider jwtProvider;
 
     @Value("${toit.auth.app-callback-uri:toit://auth/callback}")
     private String appCallbackUri;
@@ -50,9 +48,6 @@ public class AuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
                     .queryParam("accessToken", loginTokens.accessToken())
                     .queryParam("refreshToken", loginTokens.refreshToken())
                     .queryParam("nickname", user.getName());
-        } else if (loginResult == SocialLoginResult.DELETED_USER) {
-            String restoreToken = jwtProvider.createRestoreToken(userId);
-            targetUrlBuilder.queryParam("restoreToken", restoreToken);
         }
 
         clearAuthenticationAttributes(request);

--- a/src/main/java/com/toit/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/toit/auth/jwt/JwtProvider.java
@@ -69,36 +69,6 @@ public class JwtProvider {
                 .compact();
     }
 
-    /**
-     * 계정 복구용 단기 토큰 생성 (10분 유효)
-     */
-    public String createRestoreToken(Long usersId) {
-        Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + 10 * 60 * 1000L);
-
-        return Jwts.builder()
-                .subject(String.valueOf(usersId))
-                .claim("purpose", "restore")
-                .issuedAt(now)
-                .expiration(expiryDate)
-                .signWith(secretKey)
-                .compact();
-    }
-
-    public boolean isRestoreToken(String token) {
-        try {
-            String purpose = Jwts.parser()
-                    .verifyWith(secretKey)
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload()
-                    .get("purpose", String.class);
-            return "restore".equals(purpose);
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
     // JwtProvider.java에 추가
     public boolean validateToken(String token) {
         try {

--- a/src/main/java/com/toit/auth/login/SocialLoginResult.java
+++ b/src/main/java/com/toit/auth/login/SocialLoginResult.java
@@ -6,7 +6,6 @@ public enum SocialLoginResult {
     CANCELLED("cancelled"),
     NEEDS_SIGNUP("needs_signup"),
     NEEDS_ADDITIONAL_INFO("needs_additional_info"),
-    DELETED_USER("deleted_user"),
     BLOCKED("blocked"),
     FAILED("failed");
 

--- a/src/main/java/com/toit/auth/service/AppleAuthMemberService.java
+++ b/src/main/java/com/toit/auth/service/AppleAuthMemberService.java
@@ -95,7 +95,6 @@ public class AppleAuthMemberService extends OidcUserService {
     }
 
     private SocialLoginResult resolveLoginResult(Users user) {
-        if (user.isDeleted()) return SocialLoginResult.DELETED_USER;
         if (user.requiresAdditionalInfo()) return SocialLoginResult.NEEDS_ADDITIONAL_INFO;
         return SocialLoginResult.SUCCESS;
     }

--- a/src/main/java/com/toit/auth/service/AuthMemberService.java
+++ b/src/main/java/com/toit/auth/service/AuthMemberService.java
@@ -120,9 +120,6 @@ public class AuthMemberService extends DefaultOAuth2UserService {
     }
 
     private SocialLoginResult resolveLoginResult(Users user) {
-        if (user.isDeleted()) {
-            return SocialLoginResult.DELETED_USER;
-        }
         if (user.requiresAdditionalInfo()) {
             return SocialLoginResult.NEEDS_ADDITIONAL_INFO;
         }

--- a/src/main/java/com/toit/folders/Folders.java
+++ b/src/main/java/com/toit/folders/Folders.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -25,7 +26,13 @@ import org.springframework.data.annotation.CreatedDate;
 
 
 @Entity
-@Table(name = "folders")
+@Table(
+        name = "folders",
+        indexes = {
+                // 통합검색: 사용자별 활성 항목만 훑도록 스캔 대상 축소
+                @Index(name = "idx_folders_users_status", columnList = "users_id, status")
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Folders {

--- a/src/main/java/com/toit/items/attachments/AttachMents.java
+++ b/src/main/java/com/toit/items/attachments/AttachMents.java
@@ -14,12 +14,22 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Entity
-@Table(name = "attachments")
+@Table(
+        name = "attachments",
+        indexes = {
+                // 통합검색: 사용자별 활성 항목만 훑도록 스캔 대상 축소
+                @Index(
+                        name = "idx_attachments_users_status",
+                        columnList = "users_id, status, attachments_type"
+                )
+        }
+)
 @Getter
 public class AttachMents extends ItemsBase {
     @Id

--- a/src/main/java/com/toit/items/links/Links.java
+++ b/src/main/java/com/toit/items/links/Links.java
@@ -10,12 +10,19 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Entity
-@Table(name = "links")
+@Table(
+        name = "links",
+        indexes = {
+                // 통합검색: 사용자별 활성 항목만 훑도록 스캔 대상 축소
+                @Index(name = "idx_links_users_status", columnList = "users_id, status")
+        }
+)
 @Getter
 public class Links extends ItemsBase {
     @Id

--- a/src/main/java/com/toit/items/texts/Texts.java
+++ b/src/main/java/com/toit/items/texts/Texts.java
@@ -9,12 +9,19 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Entity
-@Table(name = "texts")
+@Table(
+        name = "texts",
+        indexes = {
+                // 통합검색: 사용자별 활성 항목만 훑도록 스캔 대상 축소
+                @Index(name = "idx_texts_users_status", columnList = "users_id, status")
+        }
+)
 @Getter
 public class Texts extends ItemsBase {
     @Id

--- a/src/main/java/com/toit/schedules/Schedules.java
+++ b/src/main/java/com/toit/schedules/Schedules.java
@@ -15,6 +15,13 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 
 @Entity
+@Table(
+        name = "schedules",
+        indexes = {
+                // 통합검색: 사용자별 활성 항목만 훑도록 스캔 대상 축소
+                @Index(name = "idx_schedules_users_status", columnList = "users_id, status")
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Schedules {

--- a/src/main/java/com/toit/user/Users.java
+++ b/src/main/java/com/toit/user/Users.java
@@ -100,13 +100,6 @@ public class Users {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    /**
-     * 사용자 서비스 상태가 DELETED 되면 업데이트
-     */
-    @Column(nullable = true)
-    private LocalDateTime deletedAt;
-
-
     public Users(String email, String name, String bio, String imageUrl, AuthProvider authProvider, String providerUsersId, LocalDateTime createdAt) {
         this.email = email;
         this.name = name;
@@ -138,22 +131,8 @@ public class Users {
         return email == null || email.isBlank();
     }
 
-    public boolean isDeleted() {
-        return status == EntityStatus.DELETED;
-    }
-
     public void updateName(String name) {
         this.name = name;
         this.nicknameSet = true;
-    }
-
-    public void restore() {
-        this.status = EntityStatus.ACTIVE;
-        this.deletedAt = null;
-    }
-
-    public void softDelete() {
-        this.status = EntityStatus.DELETED;
-        this.deletedAt = LocalDateTime.now();
     }
 }


### PR DESCRIPTION
## 변경 내용
- 탈퇴 계정 복구 기능 제거 (회원 탈퇴를 완전 삭제로 전환하면서 복구 대상이 사라져 죽은 코드가 됨)
- PostgreSQL → MySQL 8.0 전환을 위한 mysql-connector-j 추가 (postgresql은 롤백 대비로 당분간 유지)
- 수동 CREATE INDEX로만 존재하던 인덱스 5개를 @Table(indexes)로 코드화

## 참고
- 드라이버/방언 설정(`application.properties`)은 gitignore 대상이라 diff에 포함되지 않았습니다. MySQL 전환의 실제 스위치는 서버 환경에 반영되어 있습니다.
- 인덱스 5개는 기존에 수동 CREATE INDEX로만 존재해 DB 이전 시 유실되는 것을 발견하고 스키마와 함께 관리하도록 옮긴 것입니다.
